### PR TITLE
WIP: Add types to facilitate release of memory via finalizers.

### DIFF
--- a/examples/ida_Cable.jl
+++ b/examples/ida_Cable.jl
@@ -26,7 +26,7 @@ tf = 10.0
 dt = 0.1
 timesteps = int(tf/dt)
 t = 0.0:dt:(dt*(timesteps-1))
-    
+
 d = 4.0 * 1e-4 ## Cable diameter in cm
 R_m = 2.5e11 ## Membrane resistance in Ohms/cm^2
 G_m = 1.0/R_m ## Membrane conductance
@@ -53,18 +53,18 @@ G_J = map(i -> CoordInterpGrid(t, vec(J[:,i]), 0.0, InterpQuadratic),1:xsteps)
 ##
 
 function cableres(t, u, up, r)
-    
+
     r[:] = u ## Initialize r to u, to take care of boundary equations.
-    
+
     ## Loop over segments; set res = up - (central difference).
     for i = 2:(xsteps-2)
         loc = i
         r[loc] = C_m * up[loc] - (d/(4*R_i)) * (u[loc-1] + u[loc+1] -
                                                 2.0 * u[loc]) +
                  G_m * u[loc] - R_m * (G_J[loc])[t]
-        
+
     end
-    
+
     return (0)
 end
 
@@ -73,8 +73,8 @@ function initial ()
 
     u = zeros(xsteps)
 
-    u[2:xsteps-2] = -60.0 ## initial value -60 mV 
-    
+    u[2:xsteps-2] = -60.0 ## initial value -60 mV
+
     id = ones(xsteps)
 
     up = zeros (xsteps)
@@ -82,14 +82,14 @@ function initial ()
 
     cableres(0.0, u, up, r)
 
-    ## Copy -res into up to get correct interior initial up values. 
+    ## Copy -res into up to get correct interior initial up values.
     up[:] = -1.0 * r
 
     return (u,up,id)
-    
+
 end
 
-nvector = Sundials.nvector
+NVector = Sundials.NVector
 function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
                     id::Vector{Float64}, t::Vector{Float64};
                     reltol::Float64=1e-4, abstol::Float64=1e-6)
@@ -98,9 +98,9 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
     mem = Sundials.IDACreate()
     flag = Sundials.IDAInit(mem, cfunction(Sundials.idasolfun, Int32,
                                            (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
-                            t[1], nvector(y0), nvector(yp0))
+                            t[1], NVector(y0), NVector(yp0))
     assert (flag == 0)
-    flag = Sundials.IDASetId(mem,nvector(id))
+    flag = Sundials.IDASetId(mem,NVector(id))
     assert (flag == 0)
     flag = Sundials.IDASetUserData(mem, f)
     assert (flag == 0)

--- a/examples/ida_Heat2D.jl
+++ b/examples/ida_Heat2D.jl
@@ -36,18 +36,18 @@ const bval = 0.1
 ## central differencing on the interior points, and includes algebraic
 ## equations for the boundary values.
 ##
-## So for each interior point, the residual component has the form       
-##    r_i = u'_i - (central difference)_i                              
-## while for each boundary point, it is r_i = u_i.                     
+## So for each interior point, the residual component has the form
+##    r_i = u'_i - (central difference)_i
+## while for each boundary point, it is r_i = u_i.
 ##
 
 function heatres(t, u, up, r)
-    
+
     r[:] = u ## Initialize r to u, to take care of boundary equations.
-    
+
     ## Loop over interior points; set res = up - (central difference).
     for j = 2:(MGRID-2)
-        
+
         offset = MGRID * j
         for i = 2:(MGRID-2)
             loc = offset + i
@@ -56,7 +56,7 @@ function heatres(t, u, up, r)
                                         4.0 * u[loc])
         end
     end
-    
+
     return (0)
 end
 
@@ -65,7 +65,7 @@ function initial ()
 
     mm = MGRID
     mm1 = mm - 1
-  
+
     u  = zeros (NEQ)
     id = ones(NEQ)
 
@@ -85,7 +85,7 @@ function initial ()
 
     heatres(0.0, u, up, r)
 
-    ## Copy -res into up to get correct interior initial up values. 
+    ## Copy -res into up to get correct interior initial up values.
     up[:] = -1.0 * r
 
     ## Finally, set values of u, up, and id at boundary points.
@@ -103,10 +103,10 @@ function initial ()
 
     constraints = ones(NEQ)
     return (u,up,id,constraints)
-    
+
 end
 
-nvector = Sundials.nvector
+NVector = Sundials.NVector
 function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
                     id::Vector{Float64}, constraints::Vector{Float64},
                     t::Vector{Float64};
@@ -115,12 +115,12 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
     neq = length(y0)
     mem = Sundials.IDACreate()
     flag = Sundials.IDAInit(mem, cfunction(Sundials.idasolfun, Int32,
-                                           (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
-                            t[1], nvector(y0), nvector(yp0))
+                                           (Sundials.RealType, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Function)),
+                            t[1], NVector(y0), NVector(yp0))
     assert (flag == 0)
-    flag = Sundials.IDASetId(mem,nvector(id))
+    flag = Sundials.IDASetId(mem,NVector(id))
     assert (flag == 0)
-    flag = Sundials.IDASetConstraints(mem,nvector(constraints))
+    flag = Sundials.IDASetConstraints(mem,NVector(constraints))
     assert (flag == 0)
     flag = Sundials.IDASetUserData(mem, f)
     assert (flag == 0)

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -104,6 +104,7 @@ Base.convert(::Type{N_Vector}, nv::NVector) = nv.ptr[1]
 Base.convert(::Type{Vector{RealType}}, nv::NVector)= nv.v
 
 Base.size(nv::NVector, d...) = size(nv.v, d...)
+
 Base.getindex(nv::NVector, i::Real) = getindex(nv.v, i)
 Base.getindex(nv::NVector, i::AbstractArray) = getindex(nv.v, i)
 Base.getindex(nv::NVector, inds...) = getindex(nv.v, inds...)
@@ -112,6 +113,7 @@ Base.setindex!(nv::NVector, X, i::Real ) = setindex!(nv.v, X, i)
 Base.setindex!(nv::NVector, X, i::AbstractArray ) = setindex!(nv.v, X, i)
 Base.setindex!(nv::NVector, X, inds... ) = setindex!(nv.v, X, inds...)
 
+Base.stride(nv::NVector, k::Integer) = stride(nv.v, k)
 
 ##################################################################
 #
@@ -124,9 +126,6 @@ asarray(x::N_Vector) = pointer_to_array(N_VGetArrayPointer_Serial(x), (nvlength(
 asarray(x::Vector{RealType}) = x
 asarray(x::Ptr{RealType}, dims::Tuple) = pointer_to_array(x, dims)
 asarray(x::N_Vector, dims::Tuple) = reinterpret(RealType, asarray(x), dims)
-
-# nvector(x::Vector{RealType}) = NVector(x)
-# nvector(x::N_Vector) = x
 
 
 ##################################################################
@@ -165,11 +164,11 @@ IDASolve(mem, tout, tret, yret::Vector{RealType}, ypret::Vector{RealType}, itask
 
 # CVODE
 CVodeInit(mem, f::Function, t0, y0) =
-    CVodeInit(mem, cfunction(f, Int32, (RealType, N_Vector, N_Vector, Ptr{Void})), t0, nvector(y0))
+    CVodeInit(mem, cfunction(f, Int32, (RealType, N_Vector, N_Vector, Ptr{Void})), t0, NVector(y0))
 CVodeReInit(mem, t0, y0::Vector{RealType}) =
-    CVodeReInit(mem, t0, nvector(y0))
+    CVodeReInit(mem, t0, NVector(y0))
 CVodeSVtolerances(mem, reltol, abstol::Vector{RealType}) =
-    CVodeSVtolerances(mem, reltol, nvector(abstol))
+    CVodeSVtolerances(mem, reltol, NVector(abstol))
 CVodeGetDky(mem, t, k, dky::Vector{RealType}) =
     CVodeGetDky(mem, t, k, NVector(dky))
 CVodeGetErrWeights(mem, eweight::Vector{RealType}) =

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -104,6 +104,9 @@ Base.convert(::Type{N_Vector}, nv::NVector) = nv.ptr[1]
 Base.convert(::Type{Vector{RealType}}, nv::NVector)= nv.v
 
 Base.size(nv::NVector, d) = size(nv.v, d)
+Base.getindex(nv::NVector, inds...) = getindex(nv.v, inds...)
+Base.setindex!(nv::NVector, X, inds... ) = setindex!(nv.v, X, inds...)
+Base.stride(nv::NVector, dim) = stride(nv.v, dim)
 
 ##################################################################
 #
@@ -314,8 +317,8 @@ end
 @c Int32 CVodeSetUserData (:CVODE_ptr,Any) libsundials_cvode  ## needed to allow passing a Function through the user data
 
 function cvodefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::Function)
-    y = Sundials.asarray(y)
-    yp = Sundials.asarray(yp)
+    y = asarray(y)
+    yp = asarray(yp)
     userfun(t, y, yp)
     return int32(0)
 end
@@ -350,9 +353,9 @@ end
 @c Int32 IDASetUserData (:IDA_ptr,Any) libsundials_ida  ## needed to allow passing a Function through the user data
 
 function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::Function)
-    y = Sundials.asarray(y)
-    yp = Sundials.asarray(yp)
-    r = Sundials.asarray(r)
+    y = asarray(y)
+    yp = asarray(yp)
+    r = asarray(r)
     userfun(t, y, yp, r)
     return int32(0)   # indicates normal return
 end

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -103,10 +103,15 @@ NVector{T<:Real}(x::Vector{T}) = NVector(copy!(similar(x, RealType), x))
 Base.convert(::Type{N_Vector}, nv::NVector) = nv.ptr[1]
 Base.convert(::Type{Vector{RealType}}, nv::NVector)= nv.v
 
-Base.size(nv::NVector, d) = size(nv.v, d)
+Base.size(nv::NVector, d...) = size(nv.v, d...)
+Base.getindex(nv::NVector, i::Real) = getindex(nv.v, i)
+Base.getindex(nv::NVector, i::AbstractArray) = getindex(nv.v, i)
 Base.getindex(nv::NVector, inds...) = getindex(nv.v, inds...)
+
+Base.setindex!(nv::NVector, X, i::Real ) = setindex!(nv.v, X, i)
+Base.setindex!(nv::NVector, X, i::AbstractArray ) = setindex!(nv.v, X, i)
 Base.setindex!(nv::NVector, X, inds... ) = setindex!(nv.v, X, inds...)
-Base.stride(nv::NVector, dim) = stride(nv.v, dim)
+
 
 ##################################################################
 #
@@ -269,6 +274,8 @@ IDAQuadReInit(mem, yQ0::Vector{RealType}) =
 
 ## IDAQuadSVtolerances(mem, reltol, abstol::Vector{RealType}) =
 ##  IDAQuadSVtolerances(mem, reltol, NVector(abstol))
+
+end # isdefined(:libsundials_cvodes)
 
 ##################################################################
 #

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -165,10 +165,10 @@ IDASolve(mem, tout, tret, yret::Vector{RealType}, ypret::Vector{RealType}, itask
 
 # CVODE
 CVodeInit(mem, f::Function, t0, y0) =
-    CVodeInit(mem, cfunction(f, Int32, (realtype, N_Vector, N_Vector, Ptr{Void})), t0, nvector(y0))
-CVodeReInit(mem, t0, y0::Vector{realtype}) =
+    CVodeInit(mem, cfunction(f, Int32, (RealType, N_Vector, N_Vector, Ptr{Void})), t0, nvector(y0))
+CVodeReInit(mem, t0, y0::Vector{RealType}) =
     CVodeReInit(mem, t0, nvector(y0))
-CVodeSVtolerances(mem, reltol, abstol::Vector{realtype}) =
+CVodeSVtolerances(mem, reltol, abstol::Vector{RealType}) =
     CVodeSVtolerances(mem, reltol, nvector(abstol))
 CVodeGetDky(mem, t, k, dky::Vector{RealType}) =
     CVodeGetDky(mem, t, k, NVector(dky))

--- a/src/cvode.jl
+++ b/src/cvode.jl
@@ -42,8 +42,8 @@ typealias CVODE_ptr Ptr{CVODE_struct}
 # header: /usr/local/include/cvode/cvode_bbdpre.h
 @ctypedef CVLocalFn Ptr{:Void}
 @ctypedef CVCommFn Ptr{:Void}
-@c Int32 CVBBDPrecInit (:CVODE_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:CVLocalFn,:CVCommFn) shlib
-@c Int32 CVBBDPrecReInit (:CVODE_ptr,:Clong,:Clong,:realtype) shlib
+@c Int32 CVBBDPrecInit (:CVODE_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:RealType,:CVLocalFn,:CVCommFn) shlib
+@c Int32 CVBBDPrecReInit (:CVODE_ptr,:Clong,:Clong,:RealType) shlib
 @c Int32 CVBBDPrecGetWorkSpace (:CVODE_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Int32 CVBBDPrecGetNumGfnEvals (:CVODE_ptr,Ptr{:Clong}) shlib
 
@@ -253,25 +253,25 @@ const __codecvt_noconv = 3
 @c Int32 CVodeSetMaxNumSteps (:CVODE_ptr,:Clong) shlib
 @c Int32 CVodeSetMaxHnilWarns (:CVODE_ptr,:Int32) shlib
 @c Int32 CVodeSetStabLimDet (:CVODE_ptr,:Int32) shlib
-@c Int32 CVodeSetInitStep (:CVODE_ptr,:realtype) shlib
-@c Int32 CVodeSetMinStep (:CVODE_ptr,:realtype) shlib
-@c Int32 CVodeSetMaxStep (:CVODE_ptr,:realtype) shlib
-@c Int32 CVodeSetStopTime (:CVODE_ptr,:realtype) shlib
+@c Int32 CVodeSetInitStep (:CVODE_ptr,:RealType) shlib
+@c Int32 CVodeSetMinStep (:CVODE_ptr,:RealType) shlib
+@c Int32 CVodeSetMaxStep (:CVODE_ptr,:RealType) shlib
+@c Int32 CVodeSetStopTime (:CVODE_ptr,:RealType) shlib
 @c Int32 CVodeSetMaxErrTestFails (:CVODE_ptr,:Int32) shlib
 @c Int32 CVodeSetMaxNonlinIters (:CVODE_ptr,:Int32) shlib
 @c Int32 CVodeSetMaxConvFails (:CVODE_ptr,:Int32) shlib
-@c Int32 CVodeSetNonlinConvCoef (:CVODE_ptr,:realtype) shlib
+@c Int32 CVodeSetNonlinConvCoef (:CVODE_ptr,:RealType) shlib
 @c Int32 CVodeSetIterType (:CVODE_ptr,:Int32) shlib
 @c Int32 CVodeSetRootDirection (:CVODE_ptr,Ptr{:Int32}) shlib
 @c Int32 CVodeSetNoInactiveRootWarn (:CVODE_ptr,) shlib
-@c Int32 CVodeInit (:CVODE_ptr,:CVRhsFn,:realtype,:N_Vector) shlib
-@c Int32 CVodeReInit (:CVODE_ptr,:realtype,:N_Vector) shlib
-@c Int32 CVodeSStolerances (:CVODE_ptr,:realtype,:realtype) shlib
-@c Int32 CVodeSVtolerances (:CVODE_ptr,:realtype,:N_Vector) shlib
+@c Int32 CVodeInit (:CVODE_ptr,:CVRhsFn,:RealType,:N_Vector) shlib
+@c Int32 CVodeReInit (:CVODE_ptr,:RealType,:N_Vector) shlib
+@c Int32 CVodeSStolerances (:CVODE_ptr,:RealType,:RealType) shlib
+@c Int32 CVodeSVtolerances (:CVODE_ptr,:RealType,:N_Vector) shlib
 @c Int32 CVodeWFtolerances (:CVODE_ptr,:CVEwtFn) shlib
 @c Int32 CVodeRootInit (:CVODE_ptr,:Int32,:CVRootFn) shlib
-@c Int32 CVode (:CVODE_ptr,:realtype,:N_Vector,Ptr{:realtype},:Int32) shlib
-@c Int32 CVodeGetDky (:CVODE_ptr,:realtype,:Int32,:N_Vector) shlib
+@c Int32 CVode (:CVODE_ptr,:RealType,:N_Vector,Ptr{:RealType},:Int32) shlib
+@c Int32 CVodeGetDky (:CVODE_ptr,:RealType,:Int32,:N_Vector) shlib
 @c Int32 CVodeGetWorkSpace (:CVODE_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Int32 CVodeGetNumSteps (:CVODE_ptr,Ptr{:Clong}) shlib
 @c Int32 CVodeGetNumRhsEvals (:CVODE_ptr,Ptr{:Clong}) shlib
@@ -280,16 +280,16 @@ const __codecvt_noconv = 3
 @c Int32 CVodeGetLastOrder (:CVODE_ptr,Ptr{:Int32}) shlib
 @c Int32 CVodeGetCurrentOrder (:CVODE_ptr,Ptr{:Int32}) shlib
 @c Int32 CVodeGetNumStabLimOrderReds (:CVODE_ptr,Ptr{:Clong}) shlib
-@c Int32 CVodeGetActualInitStep (:CVODE_ptr,Ptr{:realtype}) shlib
-@c Int32 CVodeGetLastStep (:CVODE_ptr,Ptr{:realtype}) shlib
-@c Int32 CVodeGetCurrentStep (:CVODE_ptr,Ptr{:realtype}) shlib
-@c Int32 CVodeGetCurrentTime (:CVODE_ptr,Ptr{:realtype}) shlib
-@c Int32 CVodeGetTolScaleFactor (:CVODE_ptr,Ptr{:realtype}) shlib
+@c Int32 CVodeGetActualInitStep (:CVODE_ptr,Ptr{:RealType}) shlib
+@c Int32 CVodeGetLastStep (:CVODE_ptr,Ptr{:RealType}) shlib
+@c Int32 CVodeGetCurrentStep (:CVODE_ptr,Ptr{:RealType}) shlib
+@c Int32 CVodeGetCurrentTime (:CVODE_ptr,Ptr{:RealType}) shlib
+@c Int32 CVodeGetTolScaleFactor (:CVODE_ptr,Ptr{:RealType}) shlib
 @c Int32 CVodeGetErrWeights (:CVODE_ptr,:N_Vector) shlib
 @c Int32 CVodeGetEstLocalErrors (:CVODE_ptr,:N_Vector) shlib
 @c Int32 CVodeGetNumGEvals (:CVODE_ptr,Ptr{:Clong}) shlib
 @c Int32 CVodeGetRootInfo (:CVODE_ptr,Ptr{:Int32}) shlib
-@c Int32 CVodeGetIntegratorStats (:CVODE_ptr,Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
+@c Int32 CVodeGetIntegratorStats (:CVODE_ptr,Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:RealType},Ptr{:RealType},Ptr{:RealType},Ptr{:RealType}) shlib
 @c Int32 CVodeGetNumNonlinSolvIters (:CVODE_ptr,Ptr{:Clong}) shlib
 @c Int32 CVodeGetNumNonlinSolvConvFails (:CVODE_ptr,Ptr{:Clong}) shlib
 @c Int32 CVodeGetNonlinSolvStats (:CVODE_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
@@ -309,7 +309,7 @@ const __codecvt_noconv = 3
 @c Int32 CVSpilsSetPrecType (:CVODE_ptr,:Int32) shlib
 @c Int32 CVSpilsSetGSType (:CVODE_ptr,:Int32) shlib
 @c Int32 CVSpilsSetMaxl (:CVODE_ptr,:Int32) shlib
-@c Int32 CVSpilsSetEpsLin (:CVODE_ptr,:realtype) shlib
+@c Int32 CVSpilsSetEpsLin (:CVODE_ptr,:RealType) shlib
 @c Int32 CVSpilsSetPreconditioner (:CVODE_ptr,:CVSpilsPrecSetupFn,:CVSpilsPrecSolveFn) shlib
 @c Int32 CVSpilsSetJacTimesVecFn (:CVODE_ptr,:CVSpilsJacTimesVecFn) shlib
 @c Int32 CVSpilsGetWorkSpace (:CVODE_ptr,Ptr{:Clong},Ptr{:Clong}) shlib

--- a/src/cvodes.jl
+++ b/src/cvodes.jl
@@ -1,5 +1,5 @@
 
-recurs_sym_type(ex::Any) = 
+recurs_sym_type(ex::Any) =
   (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
 macro c(ret_type, func, arg_types, lib)
   local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
@@ -31,8 +31,8 @@ end
 # header: /usr/local/include/cvodes/cvodes_bbdpre.h
 @ctypedef CVLocalFnB Ptr{:Void}
 @ctypedef CVCommFnB Ptr{:Void}
-@c Int32 CVBBDPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:CVLocalFnB,:CVCommFnB) shlib
-@c Int32 CVBBDPrecReInitB (Ptr{:None},:Int32,:Clong,:Clong,:realtype) shlib
+@c Int32 CVBBDPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong,:Clong,:Clong,:RealType,:CVLocalFnB,:CVCommFnB) shlib
+@c Int32 CVBBDPrecReInitB (Ptr{:None},:Int32,:Clong,:Clong,:RealType) shlib
 
 # header: /usr/local/include/cvodes/cvodes_dense.h
 @c Int32 CVDenseB (Ptr{:None},:Int32,:Clong) shlib
@@ -53,39 +53,39 @@ end
 @ctypedef CVQuadRhsFnBS Ptr{:Void}
 @c Int32 CVodeQuadInit (Ptr{:None},:CVQuadRhsFn,:N_Vector) shlib
 @c Int32 CVodeQuadReInit (Ptr{:None},:N_Vector) shlib
-@c Int32 CVodeQuadSStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 CVodeQuadSVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
+@c Int32 CVodeQuadSStolerances (Ptr{:None},:RealType,:RealType) shlib
+@c Int32 CVodeQuadSVtolerances (Ptr{:None},:RealType,:N_Vector) shlib
 @c Int32 CVodeSensInit (Ptr{:None},:Int32,:Int32,:CVSensRhsFn,Ptr{:N_Vector}) shlib
 @c Int32 CVodeSensInit1 (Ptr{:None},:Int32,:Int32,:CVSensRhs1Fn,Ptr{:N_Vector}) shlib
 @c Int32 CVodeSensReInit (Ptr{:None},:Int32,Ptr{:N_Vector}) shlib
-@c Int32 CVodeSensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 CVodeSensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
+@c Int32 CVodeSensSStolerances (Ptr{:None},:RealType,Ptr{:RealType}) shlib
+@c Int32 CVodeSensSVtolerances (Ptr{:None},:RealType,Ptr{:N_Vector}) shlib
 @c Int32 CVodeSensEEtolerances (Ptr{:None},) shlib
 @c Int32 CVodeQuadSensInit (Ptr{:None},:CVQuadSensRhsFn,Ptr{:N_Vector}) shlib
 @c Int32 CVodeQuadSensReInit (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 CVodeQuadSensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 CVodeQuadSensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
+@c Int32 CVodeQuadSensSStolerances (Ptr{:None},:RealType,Ptr{:RealType}) shlib
+@c Int32 CVodeQuadSensSVtolerances (Ptr{:None},:RealType,Ptr{:N_Vector}) shlib
 @c Int32 CVodeQuadSensEEtolerances (Ptr{:None},) shlib
 @c None CVodeQuadFree (Ptr{:None},) shlib
 @c None CVodeSensFree (Ptr{:None},) shlib
 @c None CVodeQuadSensFree (Ptr{:None},) shlib
 @c Int32 CVodeSetQuadErrCon (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetSensDQMethod (Ptr{:None},:Int32,:realtype) shlib
+@c Int32 CVodeSetSensDQMethod (Ptr{:None},:Int32,:RealType) shlib
 @c Int32 CVodeSetSensErrCon (Ptr{:None},:Int32) shlib
 @c Int32 CVodeSetSensMaxNonlinIters (Ptr{:None},:Int32) shlib
-@c Int32 CVodeSetSensParams (Ptr{:None},Ptr{:realtype},Ptr{:realtype},Ptr{:Int32}) shlib
+@c Int32 CVodeSetSensParams (Ptr{:None},Ptr{:RealType},Ptr{:RealType},Ptr{:Int32}) shlib
 @c Int32 CVodeSetQuadSensErrCon (Ptr{:None},:Int32) shlib
 @c Int32 CVodeSensToggleOff (Ptr{:None},) shlib
-@c Int32 CVodeGetQuad (Ptr{:None},Ptr{:realtype},:N_Vector) shlib
-@c Int32 CVodeGetQuadDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
-@c Int32 CVodeGetSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 CVodeGetSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
-@c Int32 CVodeGetQuadSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetQuadSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 CVodeGetQuadSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 CVodeGetQuadSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
+@c Int32 CVodeGetQuad (Ptr{:None},Ptr{:RealType},:N_Vector) shlib
+@c Int32 CVodeGetQuadDky (Ptr{:None},:RealType,:Int32,:N_Vector) shlib
+@c Int32 CVodeGetSens (Ptr{:None},Ptr{:RealType},Ptr{:N_Vector}) shlib
+@c Int32 CVodeGetSens1 (Ptr{:None},Ptr{:RealType},:Int32,:N_Vector) shlib
+@c Int32 CVodeGetSensDky (Ptr{:None},:RealType,:Int32,Ptr{:N_Vector}) shlib
+@c Int32 CVodeGetSensDky1 (Ptr{:None},:RealType,:Int32,:Int32,:N_Vector) shlib
+@c Int32 CVodeGetQuadSens (Ptr{:None},Ptr{:RealType},Ptr{:N_Vector}) shlib
+@c Int32 CVodeGetQuadSens1 (Ptr{:None},Ptr{:RealType},:Int32,:N_Vector) shlib
+@c Int32 CVodeGetQuadSensDky (Ptr{:None},:RealType,:Int32,Ptr{:N_Vector}) shlib
+@c Int32 CVodeGetQuadSensDky1 (Ptr{:None},:RealType,:Int32,:Int32,:N_Vector) shlib
 @c Int32 CVodeGetQuadNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
 @c Int32 CVodeGetQuadNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
 @c Int32 CVodeGetQuadErrWeights (Ptr{:None},:N_Vector) shlib
@@ -109,36 +109,36 @@ end
 @c Int32 CVodeAdjReInit (Ptr{:None},) shlib
 @c None CVodeAdjFree (Ptr{:None},) shlib
 @c Int32 CVodeCreateB (Ptr{:None},:Int32,:Int32,Ptr{:Int32}) shlib
-@c Int32 CVodeInitB (Ptr{:None},:Int32,:CVRhsFnB,:realtype,:N_Vector) shlib
-@c Int32 CVodeInitBS (Ptr{:None},:Int32,:CVRhsFnBS,:realtype,:N_Vector) shlib
-@c Int32 CVodeReInitB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 CVodeSStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 CVodeSVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
+@c Int32 CVodeInitB (Ptr{:None},:Int32,:CVRhsFnB,:RealType,:N_Vector) shlib
+@c Int32 CVodeInitBS (Ptr{:None},:Int32,:CVRhsFnBS,:RealType,:N_Vector) shlib
+@c Int32 CVodeReInitB (Ptr{:None},:Int32,:RealType,:N_Vector) shlib
+@c Int32 CVodeSStolerancesB (Ptr{:None},:Int32,:RealType,:RealType) shlib
+@c Int32 CVodeSVtolerancesB (Ptr{:None},:Int32,:RealType,:N_Vector) shlib
 @c Int32 CVodeQuadInitB (Ptr{:None},:Int32,:CVQuadRhsFnB,:N_Vector) shlib
 @c Int32 CVodeQuadInitBS (Ptr{:None},:Int32,:CVQuadRhsFnBS,:N_Vector) shlib
 @c Int32 CVodeQuadReInitB (Ptr{:None},:Int32,:N_Vector) shlib
-@c Int32 CVodeQuadSStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 CVodeQuadSVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 CVodeF (Ptr{:None},:realtype,:N_Vector,Ptr{:realtype},:Int32,Ptr{:Int32}) shlib
-@c Int32 CVodeB (Ptr{:None},:realtype,:Int32) shlib
+@c Int32 CVodeQuadSStolerancesB (Ptr{:None},:Int32,:RealType,:RealType) shlib
+@c Int32 CVodeQuadSVtolerancesB (Ptr{:None},:Int32,:RealType,:N_Vector) shlib
+@c Int32 CVodeF (Ptr{:None},:RealType,:N_Vector,Ptr{:RealType},:Int32,Ptr{:Int32}) shlib
+@c Int32 CVodeB (Ptr{:None},:RealType,:Int32) shlib
 @c Int32 CVodeSetAdjNoSensi (Ptr{:None},) shlib
 @c Int32 CVodeSetIterTypeB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 CVodeSetUserDataB (Ptr{:None},:Int32,Ptr{:None}) shlib
 @c Int32 CVodeSetMaxOrdB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 CVodeSetMaxNumStepsB (Ptr{:None},:Int32,:Clong) shlib
 @c Int32 CVodeSetStabLimDetB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVodeSetInitStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVodeSetMinStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 CVodeSetMaxStepB (Ptr{:None},:Int32,:realtype) shlib
+@c Int32 CVodeSetInitStepB (Ptr{:None},:Int32,:RealType) shlib
+@c Int32 CVodeSetMinStepB (Ptr{:None},:Int32,:RealType) shlib
+@c Int32 CVodeSetMaxStepB (Ptr{:None},:Int32,:RealType) shlib
 @c Int32 CVodeSetQuadErrConB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVodeGetB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector) shlib
-@c Int32 CVodeGetQuadB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector) shlib
+@c Int32 CVodeGetB (Ptr{:None},:Int32,Ptr{:RealType},:N_Vector) shlib
+@c Int32 CVodeGetQuadB (Ptr{:None},:Int32,Ptr{:RealType},:N_Vector) shlib
 @c Ptr{:None} CVodeGetAdjCVodeBmem (Ptr{:None},:Int32) shlib
-@c Int32 CVodeGetAdjY (Ptr{:None},:realtype,:N_Vector) shlib
+@c Int32 CVodeGetAdjY (Ptr{:None},:RealType,:N_Vector) shlib
 @ctypedef CVadjCheckPointRec Void
 @c Int32 CVodeGetAdjCheckPointsInfo (Ptr{:None},Ptr{:CVadjCheckPointRec}) shlib
-@c Int32 CVodeGetAdjDataPointHermite (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector,:N_Vector) shlib
-@c Int32 CVodeGetAdjDataPointPolynomial (Ptr{:None},:Int32,Ptr{:realtype},Ptr{:Int32},:N_Vector) shlib
+@c Int32 CVodeGetAdjDataPointHermite (Ptr{:None},:Int32,Ptr{:RealType},:N_Vector,:N_Vector) shlib
+@c Int32 CVodeGetAdjDataPointPolynomial (Ptr{:None},:Int32,Ptr{:RealType},Ptr{:Int32},:N_Vector) shlib
 @c Int32 CVodeGetAdjCurrentCheckPoint (Ptr{:None},Ptr{Ptr{:None}}) shlib
 
 # header: /usr/local/include/cvodes/cvodes_impl.h
@@ -155,10 +155,10 @@ end
 @c Int32 cvEwtSet (:N_Vector,:N_Vector,Ptr{:None}) shlib
 @c None cvProcessError (:CVodeMem,:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8}) shlib
 @c None cvErrHandler (:Int32,Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
-@c Int32 cvSensRhsWrapper (:CVodeMem,:realtype,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},:N_Vector,:N_Vector) shlib
-@c Int32 cvSensRhs1Wrapper (:CVodeMem,:realtype,:N_Vector,:N_Vector,:Int32,:N_Vector,:N_Vector,:N_Vector,:N_Vector) shlib
-@c Int32 cvSensRhsInternalDQ (:Int32,:realtype,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:None},:N_Vector,:N_Vector) shlib
-@c Int32 cvSensRhs1InternalDQ (:Int32,:realtype,:N_Vector,:N_Vector,:Int32,:N_Vector,:N_Vector,Ptr{:None},:N_Vector,:N_Vector) shlib
+@c Int32 cvSensRhsWrapper (:CVodeMem,:RealType,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},:N_Vector,:N_Vector) shlib
+@c Int32 cvSensRhs1Wrapper (:CVodeMem,:RealType,:N_Vector,:N_Vector,:Int32,:N_Vector,:N_Vector,:N_Vector,:N_Vector) shlib
+@c Int32 cvSensRhsInternalDQ (:Int32,:RealType,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:None},:N_Vector,:N_Vector) shlib
+@c Int32 cvSensRhs1InternalDQ (:Int32,:RealType,:N_Vector,:N_Vector,:Int32,:N_Vector,:N_Vector,Ptr{:None},:N_Vector,:N_Vector) shlib
 
 # header: /usr/local/include/cvodes/cvodes_spbcgs.h
 @ctypedef CVSpilsPrecSetupFnB Ptr{:Void}
@@ -166,7 +166,7 @@ end
 @ctypedef CVSpilsJacTimesVecFnB Ptr{:Void}
 @c Int32 CVSpilsSetPrecTypeB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 CVSpilsSetGSTypeB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 CVSpilsSetEpslinB (Ptr{:None},:Int32,:realtype) shlib
+@c Int32 CVSpilsSetEpslinB (Ptr{:None},:Int32,:RealType) shlib
 @c Int32 CVSpilsSetMaxlB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 CVSpilsSetPreconditionerB (Ptr{:None},:Int32,:CVSpilsPrecSetupFnB,:CVSpilsPrecSolveFnB) shlib
 @c Int32 CVSpilsSetJacTimesVecFnB (Ptr{:None},:Int32,:CVSpilsJacTimesVecFnB) shlib
@@ -179,4 +179,3 @@ end
 
 # header: /usr/local/include/cvodes/cvodes_sptfqmr.h
 @c Int32 CVSptfqmrB (Ptr{:None},:Int32,:Int32,:Int32) shlib
-

--- a/src/ida.jl
+++ b/src/ida.jl
@@ -1,5 +1,5 @@
 
-recurs_sym_type(ex::Any) = 
+recurs_sym_type(ex::Any) =
   (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
 macro c(ret_type, func, arg_types, lib)
   local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
@@ -18,28 +18,32 @@ macro ctypedef(fake_t,real_t)
   end
 end
 
+type IDA_struct; end # dummy type to give us a typed pointer
+typealias IDA_ptr Ptr{IDA_struct}
+
+
 # header: /usr/local/include/ida/ida_band.h
 @ctypedef IDADlsDenseJacFn Ptr{:Void}
 @ctypedef IDADlsBandJacFn Ptr{:Void}
-@c Int32 IDADlsSetDenseJacFn (Ptr{:None},:IDADlsDenseJacFn) shlib
-@c Int32 IDADlsSetBandJacFn (Ptr{:None},:IDADlsBandJacFn) shlib
-@c Int32 IDADlsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDADlsGetNumJacEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDADlsGetNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDADlsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
+@c Int32 IDADlsSetDenseJacFn (:IDA_ptr,:IDADlsDenseJacFn) shlib
+@c Int32 IDADlsSetBandJacFn (:IDA_ptr,:IDADlsBandJacFn) shlib
+@c Int32 IDADlsGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 IDADlsGetNumJacEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDADlsGetNumResEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDADlsGetLastFlag (:IDA_ptr,Ptr{:Clong}) shlib
 @c Ptr{:Uint8} IDADlsGetReturnFlagName (:Clong,) shlib
-@c Int32 IDABand (Ptr{:None},:Clong,:Clong,:Clong) shlib
+@c Int32 IDABand (:IDA_ptr,:Clong,:Clong,:Clong) shlib
 
 # header: /usr/local/include/ida/ida_bbdpre.h
 @ctypedef IDABBDLocalFn Ptr{:Void}
 @ctypedef IDABBDCommFn Ptr{:Void}
-@c Int32 IDABBDPrecInit (Ptr{:None},:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:IDABBDLocalFn,:IDABBDCommFn) shlib
-@c Int32 IDABBDPrecReInit (Ptr{:None},:Clong,:Clong,:realtype) shlib
-@c Int32 IDABBDPrecGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDABBDPrecGetNumGfnEvals (Ptr{:None},Ptr{:Clong}) shlib
+@c Int32 IDABBDPrecInit (:IDA_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:IDABBDLocalFn,:IDABBDCommFn) shlib
+@c Int32 IDABBDPrecReInit (:IDA_ptr,:Clong,:Clong,:realtype) shlib
+@c Int32 IDABBDPrecGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 IDABBDPrecGetNumGfnEvals (:IDA_ptr,Ptr{:Clong}) shlib
 
 # header: /usr/local/include/ida/ida_dense.h
-@c Int32 IDADense (Ptr{:None},:Clong) shlib
+@c Int32 IDADense (:IDA_ptr,:Clong) shlib
 
 # header: /usr/local/include/ida/ida_direct.h
 
@@ -48,63 +52,63 @@ end
 @ctypedef IDARootFn Ptr{:Void}
 @ctypedef IDAEwtFn Ptr{:Void}
 @ctypedef IDAErrHandlerFn Ptr{:Void}
-@c Ptr{:None} IDACreate () shlib
-@c Int32 IDASetErrHandlerFn (Ptr{:None},:IDAErrHandlerFn,Ptr{:None}) shlib
-@c Int32 IDASetErrFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 IDASetUserData (Ptr{:None},Ptr{:None}) shlib
-@c Int32 IDASetMaxOrd (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNumSteps (Ptr{:None},:Clong) shlib
-@c Int32 IDASetInitStep (Ptr{:None},:realtype) shlib
-@c Int32 IDASetMaxStep (Ptr{:None},:realtype) shlib
-@c Int32 IDASetStopTime (Ptr{:None},:realtype) shlib
-@c Int32 IDASetNonlinConvCoef (Ptr{:None},:realtype) shlib
-@c Int32 IDASetMaxErrTestFails (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNonlinIters (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxConvFails (Ptr{:None},:Int32) shlib
-@c Int32 IDASetSuppressAlg (Ptr{:None},:Int32) shlib
-@c Int32 IDASetId (Ptr{:None},:N_Vector) shlib
-@c Int32 IDASetConstraints (Ptr{:None},:N_Vector) shlib
-@c Int32 IDASetRootDirection (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDASetNoInactiveRootWarn (Ptr{:None},) shlib
-@c Int32 IDAInit (Ptr{:None},:IDAResFn,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAReInit (Ptr{:None},:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDASStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 IDASVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 IDAWFtolerances (Ptr{:None},:IDAEwtFn) shlib
-@c Int32 IDASetNonlinConvCoefIC (Ptr{:None},:realtype) shlib
-@c Int32 IDASetMaxNumStepsIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNumJacsIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetMaxNumItersIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetLineSearchOffIC (Ptr{:None},:Int32) shlib
-@c Int32 IDASetStepToleranceIC (Ptr{:None},:realtype) shlib
-@c Int32 IDARootInit (Ptr{:None},:Int32,:IDARootFn) shlib
-@c Int32 IDACalcIC (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASolve (Ptr{:None},:realtype,Ptr{:realtype},:N_Vector,:N_Vector,:Int32) shlib
-@c Int32 IDAGetDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
-@c Int32 IDAGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumSteps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumLinSolvSetups (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumBacktrackOps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetConsistentIC (Ptr{:None},:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetLastOrder (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAGetCurrentOrder (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAGetActualInitStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetLastStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetCurrentStep (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetCurrentTime (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetTolScaleFactor (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 IDAGetErrWeights (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAGetEstLocalErrors (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAGetNumGEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetRootInfo (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAGetIntegratorStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 IDAGetNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNumNonlinSolvConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDAGetNonlinSolvStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
+@c :IDA_ptr IDACreate () shlib
+@c Int32 IDASetErrHandlerFn (:IDA_ptr,:IDAErrHandlerFn,Ptr{:None}) shlib
+@c Int32 IDASetErrFile (:IDA_ptr,Ptr{:FILE}) shlib
+@c Int32 IDASetUserData (:IDA_ptr,Ptr{:None}) shlib
+@c Int32 IDASetMaxOrd (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetMaxNumSteps (:IDA_ptr,:Clong) shlib
+@c Int32 IDASetInitStep (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetMaxStep (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetStopTime (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetNonlinConvCoef (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetMaxErrTestFails (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetMaxNonlinIters (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetMaxConvFails (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetSuppressAlg (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetId (:IDA_ptr,:N_Vector) shlib
+@c Int32 IDASetConstraints (:IDA_ptr,:N_Vector) shlib
+@c Int32 IDASetRootDirection (:IDA_ptr,Ptr{:Int32}) shlib
+@c Int32 IDASetNoInactiveRootWarn (:IDA_ptr,) shlib
+@c Int32 IDAInit (:IDA_ptr,:IDAResFn,:realtype,:N_Vector,:N_Vector) shlib
+@c Int32 IDAReInit (:IDA_ptr,:realtype,:N_Vector,:N_Vector) shlib
+@c Int32 IDASStolerances (:IDA_ptr,:realtype,:realtype) shlib
+@c Int32 IDASVtolerances (:IDA_ptr,:realtype,:N_Vector) shlib
+@c Int32 IDAWFtolerances (:IDA_ptr,:IDAEwtFn) shlib
+@c Int32 IDASetNonlinConvCoefIC (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetMaxNumStepsIC (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetMaxNumJacsIC (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetMaxNumItersIC (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetLineSearchOffIC (:IDA_ptr,:Int32) shlib
+@c Int32 IDASetStepToleranceIC (:IDA_ptr,:realtype) shlib
+@c Int32 IDARootInit (:IDA_ptr,:Int32,:IDARootFn) shlib
+@c Int32 IDACalcIC (:IDA_ptr,:Int32,:realtype) shlib
+@c Int32 IDASolve (:IDA_ptr,:realtype,Ptr{:realtype},:N_Vector,:N_Vector,:Int32) shlib
+@c Int32 IDAGetDky (:IDA_ptr,:realtype,:Int32,:N_Vector) shlib
+@c Int32 IDAGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 IDAGetNumSteps (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetNumResEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetNumLinSolvSetups (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetNumErrTestFails (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetNumBacktrackOps (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetConsistentIC (:IDA_ptr,:N_Vector,:N_Vector) shlib
+@c Int32 IDAGetLastOrder (:IDA_ptr,Ptr{:Int32}) shlib
+@c Int32 IDAGetCurrentOrder (:IDA_ptr,Ptr{:Int32}) shlib
+@c Int32 IDAGetActualInitStep (:IDA_ptr,Ptr{:realtype}) shlib
+@c Int32 IDAGetLastStep (:IDA_ptr,Ptr{:realtype}) shlib
+@c Int32 IDAGetCurrentStep (:IDA_ptr,Ptr{:realtype}) shlib
+@c Int32 IDAGetCurrentTime (:IDA_ptr,Ptr{:realtype}) shlib
+@c Int32 IDAGetTolScaleFactor (:IDA_ptr,Ptr{:realtype}) shlib
+@c Int32 IDAGetErrWeights (:IDA_ptr,:N_Vector) shlib
+@c Int32 IDAGetEstLocalErrors (:IDA_ptr,:N_Vector) shlib
+@c Int32 IDAGetNumGEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetRootInfo (:IDA_ptr,Ptr{:Int32}) shlib
+@c Int32 IDAGetIntegratorStats (:IDA_ptr,Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
+@c Int32 IDAGetNumNonlinSolvIters (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetNumNonlinSolvConvFails (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDAGetNonlinSolvStats (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Ptr{:Uint8} IDAGetReturnFlagName (:Clong,) shlib
-@c None IDAFree (Ptr{Ptr{:None}},) shlib
+@c None IDAFree (Ptr{:IDA_ptr},) shlib
 
 # header: /usr/local/include/ida/ida_impl.h
 @ctypedef IDAMem Ptr{:Void}
@@ -116,29 +120,28 @@ end
 @ctypedef IDASpilsPrecSetupFn Ptr{:Void}
 @ctypedef IDASpilsPrecSolveFn Ptr{:Void}
 @ctypedef IDASpilsJacTimesVecFn Ptr{:Void}
-@c Int32 IDASpilsSetPreconditioner (Ptr{:None},:IDASpilsPrecSetupFn,:IDASpilsPrecSolveFn) shlib
-@c Int32 IDASpilsSetJacTimesVecFn (Ptr{:None},:IDASpilsJacTimesVecFn) shlib
-@c Int32 IDASpilsSetGSType (Ptr{:None},:Int32) shlib
-@c Int32 IDASpilsSetMaxRestarts (Ptr{:None},:Int32) shlib
-@c Int32 IDASpilsSetMaxl (Ptr{:None},:Int32) shlib
-@c Int32 IDASpilsSetEpsLin (Ptr{:None},:realtype) shlib
-@c Int32 IDASpilsSetIncrementFactor (Ptr{:None},:realtype) shlib
-@c Int32 IDASpilsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumPrecEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumPrecSolves (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumLinIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumJtimesEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 IDASpilsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
+@c Int32 IDASpilsSetPreconditioner (:IDA_ptr,:IDASpilsPrecSetupFn,:IDASpilsPrecSolveFn) shlib
+@c Int32 IDASpilsSetJacTimesVecFn (:IDA_ptr,:IDASpilsJacTimesVecFn) shlib
+@c Int32 IDASpilsSetGSType (:IDA_ptr,:Int32) shlib
+@c Int32 IDASpilsSetMaxRestarts (:IDA_ptr,:Int32) shlib
+@c Int32 IDASpilsSetMaxl (:IDA_ptr,:Int32) shlib
+@c Int32 IDASpilsSetEpsLin (:IDA_ptr,:realtype) shlib
+@c Int32 IDASpilsSetIncrementFactor (:IDA_ptr,:realtype) shlib
+@c Int32 IDASpilsGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetNumPrecEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetNumPrecSolves (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetNumLinIters (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetNumConvFails (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetNumJtimesEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetNumResEvals (:IDA_ptr,Ptr{:Clong}) shlib
+@c Int32 IDASpilsGetLastFlag (:IDA_ptr,Ptr{:Clong}) shlib
 @c Ptr{:Uint8} IDASpilsGetReturnFlagName (:Clong,) shlib
-@c Int32 IDASpbcg (Ptr{:None},:Int32) shlib
+@c Int32 IDASpbcg (:IDA_ptr,:Int32) shlib
 
 # header: /usr/local/include/ida/ida_spgmr.h
-@c Int32 IDASpgmr (Ptr{:None},:Int32) shlib
+@c Int32 IDASpgmr (:IDA_ptr,:Int32) shlib
 
 # header: /usr/local/include/ida/ida_spils.h
 
 # header: /usr/local/include/ida/ida_sptfqmr.h
-@c Int32 IDASptfqmr (Ptr{:None},:Int32) shlib
-
+@c Int32 IDASptfqmr (:IDA_ptr,:Int32) shlib

--- a/src/ida.jl
+++ b/src/ida.jl
@@ -37,8 +37,8 @@ typealias IDA_ptr Ptr{IDA_struct}
 # header: /usr/local/include/ida/ida_bbdpre.h
 @ctypedef IDABBDLocalFn Ptr{:Void}
 @ctypedef IDABBDCommFn Ptr{:Void}
-@c Int32 IDABBDPrecInit (:IDA_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:IDABBDLocalFn,:IDABBDCommFn) shlib
-@c Int32 IDABBDPrecReInit (:IDA_ptr,:Clong,:Clong,:realtype) shlib
+@c Int32 IDABBDPrecInit (:IDA_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:RealType,:IDABBDLocalFn,:IDABBDCommFn) shlib
+@c Int32 IDABBDPrecReInit (:IDA_ptr,:Clong,:Clong,:RealType) shlib
 @c Int32 IDABBDPrecGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Int32 IDABBDPrecGetNumGfnEvals (:IDA_ptr,Ptr{:Clong}) shlib
 
@@ -58,10 +58,10 @@ typealias IDA_ptr Ptr{IDA_struct}
 @c Int32 IDASetUserData (:IDA_ptr,Ptr{:None}) shlib
 @c Int32 IDASetMaxOrd (:IDA_ptr,:Int32) shlib
 @c Int32 IDASetMaxNumSteps (:IDA_ptr,:Clong) shlib
-@c Int32 IDASetInitStep (:IDA_ptr,:realtype) shlib
-@c Int32 IDASetMaxStep (:IDA_ptr,:realtype) shlib
-@c Int32 IDASetStopTime (:IDA_ptr,:realtype) shlib
-@c Int32 IDASetNonlinConvCoef (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetInitStep (:IDA_ptr,:RealType) shlib
+@c Int32 IDASetMaxStep (:IDA_ptr,:RealType) shlib
+@c Int32 IDASetStopTime (:IDA_ptr,:RealType) shlib
+@c Int32 IDASetNonlinConvCoef (:IDA_ptr,:RealType) shlib
 @c Int32 IDASetMaxErrTestFails (:IDA_ptr,:Int32) shlib
 @c Int32 IDASetMaxNonlinIters (:IDA_ptr,:Int32) shlib
 @c Int32 IDASetMaxConvFails (:IDA_ptr,:Int32) shlib
@@ -70,21 +70,21 @@ typealias IDA_ptr Ptr{IDA_struct}
 @c Int32 IDASetConstraints (:IDA_ptr,:N_Vector) shlib
 @c Int32 IDASetRootDirection (:IDA_ptr,Ptr{:Int32}) shlib
 @c Int32 IDASetNoInactiveRootWarn (:IDA_ptr,) shlib
-@c Int32 IDAInit (:IDA_ptr,:IDAResFn,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAReInit (:IDA_ptr,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDASStolerances (:IDA_ptr,:realtype,:realtype) shlib
-@c Int32 IDASVtolerances (:IDA_ptr,:realtype,:N_Vector) shlib
+@c Int32 IDAInit (:IDA_ptr,:IDAResFn,:RealType,:N_Vector,:N_Vector) shlib
+@c Int32 IDAReInit (:IDA_ptr,:RealType,:N_Vector,:N_Vector) shlib
+@c Int32 IDASStolerances (:IDA_ptr,:RealType,:RealType) shlib
+@c Int32 IDASVtolerances (:IDA_ptr,:RealType,:N_Vector) shlib
 @c Int32 IDAWFtolerances (:IDA_ptr,:IDAEwtFn) shlib
-@c Int32 IDASetNonlinConvCoefIC (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetNonlinConvCoefIC (:IDA_ptr,:RealType) shlib
 @c Int32 IDASetMaxNumStepsIC (:IDA_ptr,:Int32) shlib
 @c Int32 IDASetMaxNumJacsIC (:IDA_ptr,:Int32) shlib
 @c Int32 IDASetMaxNumItersIC (:IDA_ptr,:Int32) shlib
 @c Int32 IDASetLineSearchOffIC (:IDA_ptr,:Int32) shlib
-@c Int32 IDASetStepToleranceIC (:IDA_ptr,:realtype) shlib
+@c Int32 IDASetStepToleranceIC (:IDA_ptr,:RealType) shlib
 @c Int32 IDARootInit (:IDA_ptr,:Int32,:IDARootFn) shlib
-@c Int32 IDACalcIC (:IDA_ptr,:Int32,:realtype) shlib
-@c Int32 IDASolve (:IDA_ptr,:realtype,Ptr{:realtype},:N_Vector,:N_Vector,:Int32) shlib
-@c Int32 IDAGetDky (:IDA_ptr,:realtype,:Int32,:N_Vector) shlib
+@c Int32 IDACalcIC (:IDA_ptr,:Int32,:RealType) shlib
+@c Int32 IDASolve (:IDA_ptr,:RealType,Ptr{:RealType},:N_Vector,:N_Vector,:Int32) shlib
+@c Int32 IDAGetDky (:IDA_ptr,:RealType,:Int32,:N_Vector) shlib
 @c Int32 IDAGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Int32 IDAGetNumSteps (:IDA_ptr,Ptr{:Clong}) shlib
 @c Int32 IDAGetNumResEvals (:IDA_ptr,Ptr{:Clong}) shlib
@@ -94,16 +94,16 @@ typealias IDA_ptr Ptr{IDA_struct}
 @c Int32 IDAGetConsistentIC (:IDA_ptr,:N_Vector,:N_Vector) shlib
 @c Int32 IDAGetLastOrder (:IDA_ptr,Ptr{:Int32}) shlib
 @c Int32 IDAGetCurrentOrder (:IDA_ptr,Ptr{:Int32}) shlib
-@c Int32 IDAGetActualInitStep (:IDA_ptr,Ptr{:realtype}) shlib
-@c Int32 IDAGetLastStep (:IDA_ptr,Ptr{:realtype}) shlib
-@c Int32 IDAGetCurrentStep (:IDA_ptr,Ptr{:realtype}) shlib
-@c Int32 IDAGetCurrentTime (:IDA_ptr,Ptr{:realtype}) shlib
-@c Int32 IDAGetTolScaleFactor (:IDA_ptr,Ptr{:realtype}) shlib
+@c Int32 IDAGetActualInitStep (:IDA_ptr,Ptr{:RealType}) shlib
+@c Int32 IDAGetLastStep (:IDA_ptr,Ptr{:RealType}) shlib
+@c Int32 IDAGetCurrentStep (:IDA_ptr,Ptr{:RealType}) shlib
+@c Int32 IDAGetCurrentTime (:IDA_ptr,Ptr{:RealType}) shlib
+@c Int32 IDAGetTolScaleFactor (:IDA_ptr,Ptr{:RealType}) shlib
 @c Int32 IDAGetErrWeights (:IDA_ptr,:N_Vector) shlib
 @c Int32 IDAGetEstLocalErrors (:IDA_ptr,:N_Vector) shlib
 @c Int32 IDAGetNumGEvals (:IDA_ptr,Ptr{:Clong}) shlib
 @c Int32 IDAGetRootInfo (:IDA_ptr,Ptr{:Int32}) shlib
-@c Int32 IDAGetIntegratorStats (:IDA_ptr,Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
+@c Int32 IDAGetIntegratorStats (:IDA_ptr,Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Clong},Ptr{:Int32},Ptr{:Int32},Ptr{:RealType},Ptr{:RealType},Ptr{:RealType},Ptr{:RealType}) shlib
 @c Int32 IDAGetNumNonlinSolvIters (:IDA_ptr,Ptr{:Clong}) shlib
 @c Int32 IDAGetNumNonlinSolvConvFails (:IDA_ptr,Ptr{:Clong}) shlib
 @c Int32 IDAGetNonlinSolvStats (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
@@ -125,8 +125,8 @@ typealias IDA_ptr Ptr{IDA_struct}
 @c Int32 IDASpilsSetGSType (:IDA_ptr,:Int32) shlib
 @c Int32 IDASpilsSetMaxRestarts (:IDA_ptr,:Int32) shlib
 @c Int32 IDASpilsSetMaxl (:IDA_ptr,:Int32) shlib
-@c Int32 IDASpilsSetEpsLin (:IDA_ptr,:realtype) shlib
-@c Int32 IDASpilsSetIncrementFactor (:IDA_ptr,:realtype) shlib
+@c Int32 IDASpilsSetEpsLin (:IDA_ptr,:RealType) shlib
+@c Int32 IDASpilsSetIncrementFactor (:IDA_ptr,:RealType) shlib
 @c Int32 IDASpilsGetWorkSpace (:IDA_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Int32 IDASpilsGetNumPrecEvals (:IDA_ptr,Ptr{:Clong}) shlib
 @c Int32 IDASpilsGetNumPrecSolves (:IDA_ptr,Ptr{:Clong}) shlib

--- a/src/idas.jl
+++ b/src/idas.jl
@@ -1,5 +1,5 @@
 
-recurs_sym_type(ex::Any) = 
+recurs_sym_type(ex::Any) =
   (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
 macro c(ret_type, func, arg_types, lib)
   local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
@@ -28,8 +28,8 @@ end
 # header: /usr/local/include/idas/idas_bbdpre.h
 @ctypedef IDABBDLocalFnB Ptr{:Void}
 @ctypedef IDABBDCommFnB Ptr{:Void}
-@c Int32 IDABBDPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:IDABBDLocalFnB,:IDABBDCommFnB) shlib
-@c Int32 IDABBDPrecReInitB (Ptr{:None},:Int32,:Clong,:Clong,:realtype) shlib
+@c Int32 IDABBDPrecInitB (Ptr{:None},:Int32,:Clong,:Clong,:Clong,:Clong,:Clong,:RealType,:IDABBDLocalFnB,:IDABBDCommFnB) shlib
+@c Int32 IDABBDPrecReInitB (Ptr{:None},:Int32,:Clong,:Clong,:RealType) shlib
 
 # header: /usr/local/include/idas/idas_dense.h
 @c Int32 IDADenseB (Ptr{:None},:Int32,:Clong) shlib
@@ -47,34 +47,34 @@ end
 @c Int32 IDASetQuadErrCon (Ptr{:None},:Int32) shlib
 @c Int32 IDAQuadInit (Ptr{:None},:IDAQuadRhsFn,:N_Vector) shlib
 @c Int32 IDAQuadReInit (Ptr{:None},:N_Vector) shlib
-@c Int32 IDAQuadSStolerances (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 IDAQuadSVtolerances (Ptr{:None},:realtype,:N_Vector) shlib
-@c Int32 IDASetSensDQMethod (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASetSensParams (Ptr{:None},Ptr{:realtype},Ptr{:realtype},Ptr{:Int32}) shlib
+@c Int32 IDAQuadSStolerances (Ptr{:None},:RealType,:RealType) shlib
+@c Int32 IDAQuadSVtolerances (Ptr{:None},:RealType,:N_Vector) shlib
+@c Int32 IDASetSensDQMethod (Ptr{:None},:Int32,:RealType) shlib
+@c Int32 IDASetSensParams (Ptr{:None},Ptr{:RealType},Ptr{:RealType},Ptr{:Int32}) shlib
 @c Int32 IDASetSensErrCon (Ptr{:None},:Int32) shlib
 @c Int32 IDASetSensMaxNonlinIters (Ptr{:None},:Int32) shlib
 @c Int32 IDASensInit (Ptr{:None},:Int32,:Int32,:IDASensResFn,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
 @c Int32 IDASensReInit (Ptr{:None},:Int32,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
 @c Int32 IDASensToggleOff (Ptr{:None},) shlib
-@c Int32 IDASensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 IDASensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
+@c Int32 IDASensSStolerances (Ptr{:None},:RealType,Ptr{:RealType}) shlib
+@c Int32 IDASensSVtolerances (Ptr{:None},:RealType,Ptr{:N_Vector}) shlib
 @c Int32 IDASensEEtolerances (Ptr{:None},) shlib
 @c Int32 IDAQuadSensInit (Ptr{:None},:IDAQuadSensRhsFn,Ptr{:N_Vector}) shlib
 @c Int32 IDAQuadSensReInit (Ptr{:None},Ptr{:N_Vector}) shlib
-@c Int32 IDAQuadSensSStolerances (Ptr{:None},:realtype,Ptr{:realtype}) shlib
-@c Int32 IDAQuadSensSVtolerances (Ptr{:None},:realtype,Ptr{:N_Vector}) shlib
+@c Int32 IDAQuadSensSStolerances (Ptr{:None},:RealType,Ptr{:RealType}) shlib
+@c Int32 IDAQuadSensSVtolerances (Ptr{:None},:RealType,Ptr{:N_Vector}) shlib
 @c Int32 IDAQuadSensEEtolerances (Ptr{:None},) shlib
 @c Int32 IDASetQuadSensErrCon (Ptr{:None},:Int32) shlib
-@c Int32 IDAGetQuad (Ptr{:None},Ptr{:realtype},:N_Vector) shlib
-@c Int32 IDAGetQuadDky (Ptr{:None},:realtype,:Int32,:N_Vector) shlib
+@c Int32 IDAGetQuad (Ptr{:None},Ptr{:RealType},:N_Vector) shlib
+@c Int32 IDAGetQuadDky (Ptr{:None},:RealType,:Int32,:N_Vector) shlib
 @c Int32 IDAGetQuadNumRhsEvals (Ptr{:None},Ptr{:Clong}) shlib
 @c Int32 IDAGetQuadNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
 @c Int32 IDAGetQuadErrWeights (Ptr{:None},:N_Vector) shlib
 @c Int32 IDAGetQuadStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 IDAGetSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 IDAGetSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 IDAGetSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
+@c Int32 IDAGetSens (Ptr{:None},Ptr{:RealType},Ptr{:N_Vector}) shlib
+@c Int32 IDAGetSens1 (Ptr{:None},Ptr{:RealType},:Int32,:N_Vector) shlib
+@c Int32 IDAGetSensDky (Ptr{:None},:RealType,:Int32,Ptr{:N_Vector}) shlib
+@c Int32 IDAGetSensDky1 (Ptr{:None},:RealType,:Int32,:Int32,:N_Vector) shlib
 @c Int32 IDAGetSensConsistentIC (Ptr{:None},Ptr{:N_Vector},Ptr{:N_Vector}) shlib
 @c Int32 IDAGetSensNumResEvals (Ptr{:None},Ptr{:Clong}) shlib
 @c Int32 IDAGetNumResEvalsSens (Ptr{:None},Ptr{:Clong}) shlib
@@ -89,10 +89,10 @@ end
 @c Int32 IDAGetQuadSensNumErrTestFails (Ptr{:None},Ptr{:Clong}) shlib
 @c Int32 IDAGetQuadSensErrWeights (Ptr{:None},Ptr{:N_Vector}) shlib
 @c Int32 IDAGetQuadSensStats (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 IDAGetQuadSens (Ptr{:None},Ptr{:realtype},Ptr{:N_Vector}) shlib
-@c Int32 IDAGetQuadSens1 (Ptr{:None},Ptr{:realtype},:Int32,:N_Vector) shlib
-@c Int32 IDAGetQuadSensDky (Ptr{:None},:realtype,:Int32,Ptr{:N_Vector}) shlib
-@c Int32 IDAGetQuadSensDky1 (Ptr{:None},:realtype,:Int32,:Int32,:N_Vector) shlib
+@c Int32 IDAGetQuadSens (Ptr{:None},Ptr{:RealType},Ptr{:N_Vector}) shlib
+@c Int32 IDAGetQuadSens1 (Ptr{:None},Ptr{:RealType},:Int32,:N_Vector) shlib
+@c Int32 IDAGetQuadSensDky (Ptr{:None},:RealType,:Int32,Ptr{:N_Vector}) shlib
+@c Int32 IDAGetQuadSensDky1 (Ptr{:None},:RealType,:Int32,:Int32,:N_Vector) shlib
 @c None IDAQuadFree (Ptr{:None},) shlib
 @c None IDASensFree (Ptr{:None},) shlib
 @c None IDAQuadSensFree (Ptr{:None},) shlib
@@ -100,39 +100,39 @@ end
 @c Int32 IDAAdjReInit (Ptr{:None},) shlib
 @c None IDAAdjFree (Ptr{:None},) shlib
 @c Int32 IDACreateB (Ptr{:None},Ptr{:Int32}) shlib
-@c Int32 IDAInitB (Ptr{:None},:Int32,:IDAResFnB,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAInitBS (Ptr{:None},:Int32,:IDAResFnBS,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDAReInitB (Ptr{:None},:Int32,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDASStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 IDASVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
+@c Int32 IDAInitB (Ptr{:None},:Int32,:IDAResFnB,:RealType,:N_Vector,:N_Vector) shlib
+@c Int32 IDAInitBS (Ptr{:None},:Int32,:IDAResFnBS,:RealType,:N_Vector,:N_Vector) shlib
+@c Int32 IDAReInitB (Ptr{:None},:Int32,:RealType,:N_Vector,:N_Vector) shlib
+@c Int32 IDASStolerancesB (Ptr{:None},:Int32,:RealType,:RealType) shlib
+@c Int32 IDASVtolerancesB (Ptr{:None},:Int32,:RealType,:N_Vector) shlib
 @c Int32 IDAQuadInitB (Ptr{:None},:Int32,:IDAQuadRhsFnB,:N_Vector) shlib
 @c Int32 IDAQuadInitBS (Ptr{:None},:Int32,:IDAQuadRhsFnBS,:N_Vector) shlib
 @c Int32 IDAQuadReInitB (Ptr{:None},:Int32,:N_Vector) shlib
-@c Int32 IDAQuadSStolerancesB (Ptr{:None},:Int32,:realtype,:realtype) shlib
-@c Int32 IDAQuadSVtolerancesB (Ptr{:None},:Int32,:realtype,:N_Vector) shlib
-@c Int32 IDACalcICB (Ptr{:None},:Int32,:realtype,:N_Vector,:N_Vector) shlib
-@c Int32 IDACalcICBS (Ptr{:None},:Int32,:realtype,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
-@c Int32 IDASolveF (Ptr{:None},:realtype,Ptr{:realtype},:N_Vector,:N_Vector,:Int32,Ptr{:Int32}) shlib
-@c Int32 IDASolveB (Ptr{:None},:realtype,:Int32) shlib
+@c Int32 IDAQuadSStolerancesB (Ptr{:None},:Int32,:RealType,:RealType) shlib
+@c Int32 IDAQuadSVtolerancesB (Ptr{:None},:Int32,:RealType,:N_Vector) shlib
+@c Int32 IDACalcICB (Ptr{:None},:Int32,:RealType,:N_Vector,:N_Vector) shlib
+@c Int32 IDACalcICBS (Ptr{:None},:Int32,:RealType,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector}) shlib
+@c Int32 IDASolveF (Ptr{:None},:RealType,Ptr{:RealType},:N_Vector,:N_Vector,:Int32,Ptr{:Int32}) shlib
+@c Int32 IDASolveB (Ptr{:None},:RealType,:Int32) shlib
 @c Int32 IDASetAdjNoSensi (Ptr{:None},) shlib
 @c Int32 IDASetUserDataB (Ptr{:None},:Int32,Ptr{:None}) shlib
 @c Int32 IDASetMaxOrdB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 IDASetMaxNumStepsB (Ptr{:None},:Int32,:Clong) shlib
-@c Int32 IDASetInitStepB (Ptr{:None},:Int32,:realtype) shlib
-@c Int32 IDASetMaxStepB (Ptr{:None},:Int32,:realtype) shlib
+@c Int32 IDASetInitStepB (Ptr{:None},:Int32,:RealType) shlib
+@c Int32 IDASetMaxStepB (Ptr{:None},:Int32,:RealType) shlib
 @c Int32 IDASetSuppressAlgB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 IDASetIdB (Ptr{:None},:Int32,:N_Vector) shlib
 @c Int32 IDASetConstraintsB (Ptr{:None},:Int32,:N_Vector) shlib
 @c Int32 IDASetQuadErrConB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDAGetB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetQuadB (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector) shlib
+@c Int32 IDAGetB (Ptr{:None},:Int32,Ptr{:RealType},:N_Vector,:N_Vector) shlib
+@c Int32 IDAGetQuadB (Ptr{:None},:Int32,Ptr{:RealType},:N_Vector) shlib
 @c Ptr{:None} IDAGetAdjIDABmem (Ptr{:None},:Int32) shlib
 @c Int32 IDAGetConsistentICB (Ptr{:None},:Int32,:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetAdjY (Ptr{:None},:realtype,:N_Vector,:N_Vector) shlib
+@c Int32 IDAGetAdjY (Ptr{:None},:RealType,:N_Vector,:N_Vector) shlib
 @ctypedef IDAadjCheckPointRec Void
 @c Int32 IDAGetAdjCheckPointsInfo (Ptr{:None},Ptr{:IDAadjCheckPointRec}) shlib
-@c Int32 IDAGetAdjDataPointHermite (Ptr{:None},:Int32,Ptr{:realtype},:N_Vector,:N_Vector) shlib
-@c Int32 IDAGetAdjDataPointPolynomial (Ptr{:None},:Int32,Ptr{:realtype},Ptr{:Int32},:N_Vector) shlib
+@c Int32 IDAGetAdjDataPointHermite (Ptr{:None},:Int32,Ptr{:RealType},:N_Vector,:N_Vector) shlib
+@c Int32 IDAGetAdjDataPointPolynomial (Ptr{:None},:Int32,Ptr{:RealType},Ptr{:Int32},:N_Vector) shlib
 @c Int32 IDAGetAdjCurrentCheckPoint (Ptr{:None},Ptr{Ptr{:None}}) shlib
 
 # header: /usr/local/include/idas/idas_impl.h
@@ -142,7 +142,7 @@ end
 @ctypedef IDAAMFreeFn Ptr{:Void}
 @ctypedef IDAAGetYFn Ptr{:Void}
 @ctypedef IDAAStorePntFn Ptr{:Void}
-@c Int32 IDASensResDQ (:Int32,:realtype,:N_Vector,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:None},:N_Vector,:N_Vector,:N_Vector) shlib
+@c Int32 IDASensResDQ (:Int32,:RealType,:N_Vector,:N_Vector,:N_Vector,Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:N_Vector},Ptr{:None},:N_Vector,:N_Vector,:N_Vector) shlib
 
 # header: /usr/local/include/idas/idas_spbcgs.h
 @ctypedef IDASpilsPrecSetupFnB Ptr{:Void}
@@ -150,9 +150,9 @@ end
 @ctypedef IDASpilsJacTimesVecFnB Ptr{:Void}
 @c Int32 IDASpilsSetGSTypeB (Ptr{:None},:Int32,:Int32) shlib
 @c Int32 IDASpilsSetMaxRestartsB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASpilsSetEpsLinB (Ptr{:None},:Int32,:realtype) shlib
+@c Int32 IDASpilsSetEpsLinB (Ptr{:None},:Int32,:RealType) shlib
 @c Int32 IDASpilsSetMaxlB (Ptr{:None},:Int32,:Int32) shlib
-@c Int32 IDASpilsSetIncrementFactorB (Ptr{:None},:Int32,:realtype) shlib
+@c Int32 IDASpilsSetIncrementFactorB (Ptr{:None},:Int32,:RealType) shlib
 @c Int32 IDASpilsSetPreconditionerB (Ptr{:None},:Int32,:IDASpilsPrecSetupFnB,:IDASpilsPrecSolveFnB) shlib
 @c Int32 IDASpilsSetJacTimesVecFnB (Ptr{:None},:Int32,:IDASpilsJacTimesVecFnB) shlib
 @c Int32 IDASpbcgB (Ptr{:None},:Int32,:Int32) shlib
@@ -164,4 +164,3 @@ end
 
 # header: /usr/local/include/idas/idas_sptfqmr.h
 @c Int32 IDASptfqmrB (Ptr{:None},:Int32,:Int32) shlib
-

--- a/src/kinsol.jl
+++ b/src/kinsol.jl
@@ -38,7 +38,7 @@ typealias KINSOL_ptr Ptr{KINSOL_struct}
 # header: /usr/local/include/kinsol/kinsol_bbdpre.h
 @ctypedef KINCommFn Ptr{:Void}
 @ctypedef KINLocalFn Ptr{:Void}
-@c Int32 KINBBDPrecInit (:KINSOL_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:KINLocalFn,:KINCommFn) shlib
+@c Int32 KINBBDPrecInit (:KINSOL_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:RealType,:KINLocalFn,:KINCommFn) shlib
 @c Int32 KINBBDPrecGetWorkSpace (:KINSOL_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
 @c Int32 KINBBDPrecGetNumGfnEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
 
@@ -64,16 +64,16 @@ typealias KINSOL_ptr Ptr{KINSOL_struct}
 @c Int32 KINSetMaxSetupCalls (:KINSOL_ptr,:Clong) shlib
 @c Int32 KINSetMaxSubSetupCalls (:KINSOL_ptr,:Clong) shlib
 @c Int32 KINSetEtaForm (:KINSOL_ptr,:Int32) shlib
-@c Int32 KINSetEtaConstValue (:KINSOL_ptr,:realtype) shlib
-@c Int32 KINSetEtaParams (:KINSOL_ptr,:realtype,:realtype) shlib
-@c Int32 KINSetResMonParams (:KINSOL_ptr,:realtype,:realtype) shlib
-@c Int32 KINSetResMonConstValue (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetEtaConstValue (:KINSOL_ptr,:RealType) shlib
+@c Int32 KINSetEtaParams (:KINSOL_ptr,:RealType,:RealType) shlib
+@c Int32 KINSetResMonParams (:KINSOL_ptr,:RealType,:RealType) shlib
+@c Int32 KINSetResMonConstValue (:KINSOL_ptr,:RealType) shlib
 @c Int32 KINSetNoMinEps (:KINSOL_ptr,:Int32) shlib
-@c Int32 KINSetMaxNewtonStep (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetMaxNewtonStep (:KINSOL_ptr,:RealType) shlib
 @c Int32 KINSetMaxBetaFails (:KINSOL_ptr,:Clong) shlib
-@c Int32 KINSetRelErrFunc (:KINSOL_ptr,:realtype) shlib
-@c Int32 KINSetFuncNormTol (:KINSOL_ptr,:realtype) shlib
-@c Int32 KINSetScaledStepTol (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetRelErrFunc (:KINSOL_ptr,:RealType) shlib
+@c Int32 KINSetFuncNormTol (:KINSOL_ptr,:RealType) shlib
+@c Int32 KINSetScaledStepTol (:KINSOL_ptr,:RealType) shlib
 @c Int32 KINSetConstraints (:KINSOL_ptr,:N_Vector) shlib
 @c Int32 KINSetSysFunc (:KINSOL_ptr,:KINSysFn) shlib
 @c Int32 KINInit (:KINSOL_ptr,:KINSysFn,:N_Vector) shlib
@@ -83,8 +83,8 @@ typealias KINSOL_ptr Ptr{KINSOL_struct}
 @c Int32 KINGetNumFuncEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
 @c Int32 KINGetNumBetaCondFails (:KINSOL_ptr,Ptr{:Clong}) shlib
 @c Int32 KINGetNumBacktrackOps (:KINSOL_ptr,Ptr{:Clong}) shlib
-@c Int32 KINGetFuncNorm (:KINSOL_ptr,Ptr{:realtype}) shlib
-@c Int32 KINGetStepLength (:KINSOL_ptr,Ptr{:realtype}) shlib
+@c Int32 KINGetFuncNorm (:KINSOL_ptr,Ptr{:RealType}) shlib
+@c Int32 KINGetStepLength (:KINSOL_ptr,Ptr{:RealType}) shlib
 @c Ptr{:Uint8} KINGetReturnFlagName (:Clong,) shlib
 @c None KINFree (Ptr{:KINSOL_ptr},) shlib
 

--- a/src/kinsol.jl
+++ b/src/kinsol.jl
@@ -1,5 +1,5 @@
 
-recurs_sym_type(ex::Any) = 
+recurs_sym_type(ex::Any) =
   (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
 macro c(ret_type, func, arg_types, lib)
   local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
@@ -18,27 +18,32 @@ macro ctypedef(fake_t,real_t)
   end
 end
 
+
+type KINSOL_struct; end # dummy type to give us a typed pointer
+typealias KINSOL_ptr Ptr{KINSOL_struct}
+
+
 # header: /usr/local/include/kinsol/kinsol_band.h
 @ctypedef KINDlsDenseJacFn Ptr{:Void}
 @ctypedef KINDlsBandJacFn Ptr{:Void}
-@c Int32 KINDlsSetDenseJacFn (Ptr{:None},:KINDlsDenseJacFn) shlib
-@c Int32 KINDlsSetBandJacFn (Ptr{:None},:KINDlsBandJacFn) shlib
-@c Int32 KINDlsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINDlsGetNumJacEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINDlsGetNumFuncEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINDlsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
+@c Int32 KINDlsSetDenseJacFn (:KINSOL_ptr,:KINDlsDenseJacFn) shlib
+@c Int32 KINDlsSetBandJacFn (:KINSOL_ptr,:KINDlsBandJacFn) shlib
+@c Int32 KINDlsGetWorkSpace (:KINSOL_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 KINDlsGetNumJacEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINDlsGetNumFuncEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINDlsGetLastFlag (:KINSOL_ptr,Ptr{:Clong}) shlib
 @c Ptr{:Uint8} KINDlsGetReturnFlagName (:Clong,) shlib
-@c Int32 KINBand (Ptr{:None},:Clong,:Clong,:Clong) shlib
+@c Int32 KINBand (:KINSOL_ptr,:Clong,:Clong,:Clong) shlib
 
 # header: /usr/local/include/kinsol/kinsol_bbdpre.h
 @ctypedef KINCommFn Ptr{:Void}
 @ctypedef KINLocalFn Ptr{:Void}
-@c Int32 KINBBDPrecInit (Ptr{:None},:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:KINLocalFn,:KINCommFn) shlib
-@c Int32 KINBBDPrecGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINBBDPrecGetNumGfnEvals (Ptr{:None},Ptr{:Clong}) shlib
+@c Int32 KINBBDPrecInit (:KINSOL_ptr,:Clong,:Clong,:Clong,:Clong,:Clong,:realtype,:KINLocalFn,:KINCommFn) shlib
+@c Int32 KINBBDPrecGetWorkSpace (:KINSOL_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 KINBBDPrecGetNumGfnEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
 
 # header: /usr/local/include/kinsol/kinsol_dense.h
-@c Int32 KINDense (Ptr{:None},:Clong) shlib
+@c Int32 KINDense (:KINSOL_ptr,:Clong) shlib
 
 # header: /usr/local/include/kinsol/kinsol_direct.h
 
@@ -46,42 +51,42 @@ end
 @ctypedef KINSysFn Ptr{:Void}
 @ctypedef KINErrHandlerFn Ptr{:Void}
 @ctypedef KINInfoHandlerFn Ptr{:Void}
-@c Ptr{:None} KINCreate () shlib
-@c Int32 KINSetErrHandlerFn (Ptr{:None},:KINErrHandlerFn,Ptr{:None}) shlib
-@c Int32 KINSetErrFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 KINSetInfoHandlerFn (Ptr{:None},:KINInfoHandlerFn,Ptr{:None}) shlib
-@c Int32 KINSetInfoFile (Ptr{:None},Ptr{:FILE}) shlib
-@c Int32 KINSetUserData (Ptr{:None},Ptr{:None}) shlib
-@c Int32 KINSetPrintLevel (Ptr{:None},:Int32) shlib
-@c Int32 KINSetNumMaxIters (Ptr{:None},:Clong) shlib
-@c Int32 KINSetNoInitSetup (Ptr{:None},:Int32) shlib
-@c Int32 KINSetNoResMon (Ptr{:None},:Int32) shlib
-@c Int32 KINSetMaxSetupCalls (Ptr{:None},:Clong) shlib
-@c Int32 KINSetMaxSubSetupCalls (Ptr{:None},:Clong) shlib
-@c Int32 KINSetEtaForm (Ptr{:None},:Int32) shlib
-@c Int32 KINSetEtaConstValue (Ptr{:None},:realtype) shlib
-@c Int32 KINSetEtaParams (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 KINSetResMonParams (Ptr{:None},:realtype,:realtype) shlib
-@c Int32 KINSetResMonConstValue (Ptr{:None},:realtype) shlib
-@c Int32 KINSetNoMinEps (Ptr{:None},:Int32) shlib
-@c Int32 KINSetMaxNewtonStep (Ptr{:None},:realtype) shlib
-@c Int32 KINSetMaxBetaFails (Ptr{:None},:Clong) shlib
-@c Int32 KINSetRelErrFunc (Ptr{:None},:realtype) shlib
-@c Int32 KINSetFuncNormTol (Ptr{:None},:realtype) shlib
-@c Int32 KINSetScaledStepTol (Ptr{:None},:realtype) shlib
-@c Int32 KINSetConstraints (Ptr{:None},:N_Vector) shlib
-@c Int32 KINSetSysFunc (Ptr{:None},:KINSysFn) shlib
-@c Int32 KINInit (Ptr{:None},:KINSysFn,:N_Vector) shlib
-@c Int32 KINSol (Ptr{:None},:N_Vector,:Int32,:N_Vector,:N_Vector) shlib
-@c Int32 KINGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINGetNumNonlinSolvIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetNumFuncEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetNumBetaCondFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetNumBacktrackOps (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINGetFuncNorm (Ptr{:None},Ptr{:realtype}) shlib
-@c Int32 KINGetStepLength (Ptr{:None},Ptr{:realtype}) shlib
+@c KINSOL_ptr KINCreate () shlib
+@c Int32 KINSetErrHandlerFn (:KINSOL_ptr,:KINErrHandlerFn,Ptr{:None}) shlib
+@c Int32 KINSetErrFile (:KINSOL_ptr,Ptr{:FILE}) shlib
+@c Int32 KINSetInfoHandlerFn (:KINSOL_ptr,:KINInfoHandlerFn,Ptr{:None}) shlib
+@c Int32 KINSetInfoFile (:KINSOL_ptr,Ptr{:FILE}) shlib
+@c Int32 KINSetUserData (:KINSOL_ptr,Ptr{:None}) shlib
+@c Int32 KINSetPrintLevel (:KINSOL_ptr,:Int32) shlib
+@c Int32 KINSetNumMaxIters (:KINSOL_ptr,:Clong) shlib
+@c Int32 KINSetNoInitSetup (:KINSOL_ptr,:Int32) shlib
+@c Int32 KINSetNoResMon (:KINSOL_ptr,:Int32) shlib
+@c Int32 KINSetMaxSetupCalls (:KINSOL_ptr,:Clong) shlib
+@c Int32 KINSetMaxSubSetupCalls (:KINSOL_ptr,:Clong) shlib
+@c Int32 KINSetEtaForm (:KINSOL_ptr,:Int32) shlib
+@c Int32 KINSetEtaConstValue (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetEtaParams (:KINSOL_ptr,:realtype,:realtype) shlib
+@c Int32 KINSetResMonParams (:KINSOL_ptr,:realtype,:realtype) shlib
+@c Int32 KINSetResMonConstValue (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetNoMinEps (:KINSOL_ptr,:Int32) shlib
+@c Int32 KINSetMaxNewtonStep (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetMaxBetaFails (:KINSOL_ptr,:Clong) shlib
+@c Int32 KINSetRelErrFunc (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetFuncNormTol (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetScaledStepTol (:KINSOL_ptr,:realtype) shlib
+@c Int32 KINSetConstraints (:KINSOL_ptr,:N_Vector) shlib
+@c Int32 KINSetSysFunc (:KINSOL_ptr,:KINSysFn) shlib
+@c Int32 KINInit (:KINSOL_ptr,:KINSysFn,:N_Vector) shlib
+@c Int32 KINSol (:KINSOL_ptr,:N_Vector,:Int32,:N_Vector,:N_Vector) shlib
+@c Int32 KINGetWorkSpace (:KINSOL_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 KINGetNumNonlinSolvIters (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINGetNumFuncEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINGetNumBetaCondFails (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINGetNumBacktrackOps (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINGetFuncNorm (:KINSOL_ptr,Ptr{:realtype}) shlib
+@c Int32 KINGetStepLength (:KINSOL_ptr,Ptr{:realtype}) shlib
 @c Ptr{:Uint8} KINGetReturnFlagName (:Clong,) shlib
-@c None KINFree (Ptr{Ptr{:None}},) shlib
+@c None KINFree (Ptr{:KINSOL_ptr},) shlib
 
 # header: /usr/local/include/kinsol/kinsol_impl.h
 @ctypedef KINMem Ptr{:Void}
@@ -91,28 +96,27 @@ end
 @c None KINInfoHandler (Ptr{:Uint8},Ptr{:Uint8},Ptr{:Uint8},Ptr{:None}) shlib
 
 # header: /usr/local/include/kinsol/kinsol_spbcgs.h
+@c Int32 KINSpbcg (:KINSOL_ptr,:Int32) shlib
+
+# header: /usr/local/include/kinsol/kinsol_spgmr.h
+@c Int32 KINSpgmr (:KINSOL_ptr,:Int32) shlib
+
+# header: /usr/local/include/kinsol/kinsol_spils.h
 @ctypedef KINSpilsPrecSetupFn Ptr{:Void}
 @ctypedef KINSpilsPrecSolveFn Ptr{:Void}
 @ctypedef KINSpilsJacTimesVecFn Ptr{:Void}
-@c Int32 KINSpilsSetMaxRestarts (Ptr{:None},:Int32) shlib
-@c Int32 KINSpilsSetPreconditioner (Ptr{:None},:KINSpilsPrecSetupFn,:KINSpilsPrecSolveFn) shlib
-@c Int32 KINSpilsSetJacTimesVecFn (Ptr{:None},:KINSpilsJacTimesVecFn) shlib
-@c Int32 KINSpilsGetWorkSpace (Ptr{:None},Ptr{:Clong},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumPrecEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumPrecSolves (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumLinIters (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumConvFails (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumJtimesEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetNumFuncEvals (Ptr{:None},Ptr{:Clong}) shlib
-@c Int32 KINSpilsGetLastFlag (Ptr{:None},Ptr{:Clong}) shlib
+@c Int32 KINSpilsSetMaxRestarts (:KINSOL_ptr,:Int32) shlib
+@c Int32 KINSpilsSetPreconditioner (:KINSOL_ptr,:KINSpilsPrecSetupFn,:KINSpilsPrecSolveFn) shlib
+@c Int32 KINSpilsSetJacTimesVecFn (:KINSOL_ptr,:KINSpilsJacTimesVecFn) shlib
+@c Int32 KINSpilsGetWorkSpace (:KINSOL_ptr,Ptr{:Clong},Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetNumPrecEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetNumPrecSolves (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetNumLinIters (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetNumConvFails (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetNumJtimesEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetNumFuncEvals (:KINSOL_ptr,Ptr{:Clong}) shlib
+@c Int32 KINSpilsGetLastFlag (:KINSOL_ptr,Ptr{:Clong}) shlib
 @c Ptr{:Uint8} KINSpilsGetReturnFlagName (:Clong,) shlib
-@c Int32 KINSpbcg (Ptr{:None},:Int32) shlib
-
-# header: /usr/local/include/kinsol/kinsol_spgmr.h
-@c Int32 KINSpgmr (Ptr{:None},:Int32) shlib
-
-# header: /usr/local/include/kinsol/kinsol_spils.h
 
 # header: /usr/local/include/kinsol/kinsol_sptfqmr.h
-@c Int32 KINSptfqmr (Ptr{:None},:Int32) shlib
-
+@c Int32 KINSptfqmr (:KINSOL_ptr,:Int32) shlib

--- a/src/libsundials.jl
+++ b/src/libsundials.jl
@@ -1,5 +1,5 @@
 
-recurs_sym_type(ex::Any) = 
+recurs_sym_type(ex::Any) =
   (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
 macro c(ret_type, func, arg_types, lib)
   local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
@@ -25,48 +25,48 @@ end
 @c None DestroyMat (:DlsMat,) shlib
 @c Ptr{:Int32} NewIntArray (:Int32,) shlib
 @c Ptr{:Clong} NewLintArray (:Clong,) shlib
-@c Ptr{:realtype} NewRealArray (:Clong,) shlib
+@c Ptr{:RealType} NewRealArray (:Clong,) shlib
 @c None DestroyArray (Ptr{:None},) shlib
 @c None AddIdentity (:DlsMat,) shlib
 @c None SetToZero (:DlsMat,) shlib
 @c None PrintMat (:DlsMat,) shlib
-@c Ptr{Ptr{:realtype}} newDenseMat (:Clong,:Clong) shlib
-@c Ptr{Ptr{:realtype}} newBandMat (:Clong,:Clong,:Clong) shlib
-@c None destroyMat (Ptr{Ptr{:realtype}},) shlib
+@c Ptr{Ptr{:RealType}} newDenseMat (:Clong,:Clong) shlib
+@c Ptr{Ptr{:RealType}} newBandMat (:Clong,:Clong,:Clong) shlib
+@c None destroyMat (Ptr{Ptr{:RealType}},) shlib
 @c Ptr{:Int32} newIntArray (:Int32,) shlib
 @c Ptr{:Clong} newLintArray (:Clong,) shlib
-@c Ptr{:realtype} newRealArray (:Clong,) shlib
+@c Ptr{:RealType} newRealArray (:Clong,) shlib
 @c None destroyArray (Ptr{:None},) shlib
 @c Clong BandGBTRF (:DlsMat,Ptr{:Clong}) shlib
-@c Clong bandGBTRF (Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,:Clong,Ptr{:Clong}) shlib
-@c None BandGBTRS (:DlsMat,Ptr{:Clong},Ptr{:realtype}) shlib
-@c None bandGBTRS (Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,Ptr{:Clong},Ptr{:realtype}) shlib
+@c Clong bandGBTRF (Ptr{Ptr{:RealType}},:Clong,:Clong,:Clong,:Clong,Ptr{:Clong}) shlib
+@c None BandGBTRS (:DlsMat,Ptr{:Clong},Ptr{:RealType}) shlib
+@c None bandGBTRS (Ptr{Ptr{:RealType}},:Clong,:Clong,:Clong,Ptr{:Clong},Ptr{:RealType}) shlib
 @c None BandCopy (:DlsMat,:DlsMat,:Clong,:Clong) shlib
-@c None bandCopy (Ptr{Ptr{:realtype}},Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,:Clong,:Clong) shlib
-@c None BandScale (:realtype,:DlsMat) shlib
-@c None bandScale (:realtype,Ptr{Ptr{:realtype}},:Clong,:Clong,:Clong,:Clong) shlib
-@c None bandAddIdentity (Ptr{Ptr{:realtype}},:Clong,:Clong) shlib
+@c None bandCopy (Ptr{Ptr{:RealType}},Ptr{Ptr{:RealType}},:Clong,:Clong,:Clong,:Clong,:Clong) shlib
+@c None BandScale (:RealType,:DlsMat) shlib
+@c None bandScale (:RealType,Ptr{Ptr{:RealType}},:Clong,:Clong,:Clong,:Clong) shlib
+@c None bandAddIdentity (Ptr{Ptr{:RealType}},:Clong,:Clong) shlib
 
 # header: /usr/local/include/sundials/sundials_config.h
 
 # header: /usr/local/include/sundials/sundials_dense.h
 @c Clong DenseGETRF (:DlsMat,Ptr{:Clong}) shlib
-@c None DenseGETRS (:DlsMat,Ptr{:Clong},Ptr{:realtype}) shlib
-@c Clong denseGETRF (Ptr{Ptr{:realtype}},:Clong,:Clong,Ptr{:Clong}) shlib
-@c None denseGETRS (Ptr{Ptr{:realtype}},:Clong,Ptr{:Clong},Ptr{:realtype}) shlib
+@c None DenseGETRS (:DlsMat,Ptr{:Clong},Ptr{:RealType}) shlib
+@c Clong denseGETRF (Ptr{Ptr{:RealType}},:Clong,:Clong,Ptr{:Clong}) shlib
+@c None denseGETRS (Ptr{Ptr{:RealType}},:Clong,Ptr{:Clong},Ptr{:RealType}) shlib
 @c Clong DensePOTRF (:DlsMat,) shlib
-@c None DensePOTRS (:DlsMat,Ptr{:realtype}) shlib
-@c Clong densePOTRF (Ptr{Ptr{:realtype}},:Clong) shlib
-@c None densePOTRS (Ptr{Ptr{:realtype}},:Clong,Ptr{:realtype}) shlib
-@c Int32 DenseGEQRF (:DlsMat,Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 DenseORMQR (:DlsMat,Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 denseGEQRF (Ptr{Ptr{:realtype}},:Clong,:Clong,Ptr{:realtype},Ptr{:realtype}) shlib
-@c Int32 denseORMQR (Ptr{Ptr{:realtype}},:Clong,:Clong,Ptr{:realtype},Ptr{:realtype},Ptr{:realtype},Ptr{:realtype}) shlib
+@c None DensePOTRS (:DlsMat,Ptr{:RealType}) shlib
+@c Clong densePOTRF (Ptr{Ptr{:RealType}},:Clong) shlib
+@c None densePOTRS (Ptr{Ptr{:RealType}},:Clong,Ptr{:RealType}) shlib
+@c Int32 DenseGEQRF (:DlsMat,Ptr{:RealType},Ptr{:RealType}) shlib
+@c Int32 DenseORMQR (:DlsMat,Ptr{:RealType},Ptr{:RealType},Ptr{:RealType},Ptr{:RealType}) shlib
+@c Int32 denseGEQRF (Ptr{Ptr{:RealType}},:Clong,:Clong,Ptr{:RealType},Ptr{:RealType}) shlib
+@c Int32 denseORMQR (Ptr{Ptr{:RealType}},:Clong,:Clong,Ptr{:RealType},Ptr{:RealType},Ptr{:RealType},Ptr{:RealType}) shlib
 @c None DenseCopy (:DlsMat,:DlsMat) shlib
-@c None denseCopy (Ptr{Ptr{:realtype}},Ptr{Ptr{:realtype}},:Clong,:Clong) shlib
-@c None DenseScale (:realtype,:DlsMat) shlib
-@c None denseScale (:realtype,Ptr{Ptr{:realtype}},:Clong,:Clong) shlib
-@c None denseAddIdentity (Ptr{Ptr{:realtype}},:Clong) shlib
+@c None denseCopy (Ptr{Ptr{:RealType}},Ptr{Ptr{:RealType}},:Clong,:Clong) shlib
+@c None DenseScale (:RealType,:DlsMat) shlib
+@c None denseScale (:RealType,Ptr{Ptr{:RealType}},:Clong,:Clong) shlib
+@c None denseAddIdentity (Ptr{Ptr{:RealType}},:Clong) shlib
 
 # header: /usr/local/include/sundials/sundials_direct.h
 
@@ -86,17 +86,17 @@ const MODIFIED_GS = 1
 const CLASSICAL_GS = 2
 # end
 @ctypedef PSolveFn Ptr{:Void}
-@c Int32 ModifiedGS (Ptr{:N_Vector},Ptr{Ptr{:realtype}},:Int32,:Int32,Ptr{:realtype}) shlib
-@c Int32 ClassicalGS (Ptr{:N_Vector},Ptr{Ptr{:realtype}},:Int32,:Int32,Ptr{:realtype},:N_Vector,Ptr{:realtype}) shlib
-@c Int32 QRfact (:Int32,Ptr{Ptr{:realtype}},Ptr{:realtype},:Int32) shlib
-@c Int32 QRsol (:Int32,Ptr{Ptr{:realtype}},Ptr{:realtype},Ptr{:realtype}) shlib
+@c Int32 ModifiedGS (Ptr{:N_Vector},Ptr{Ptr{:RealType}},:Int32,:Int32,Ptr{:RealType}) shlib
+@c Int32 ClassicalGS (Ptr{:N_Vector},Ptr{Ptr{:RealType}},:Int32,:Int32,Ptr{:RealType},:N_Vector,Ptr{:RealType}) shlib
+@c Int32 QRfact (:Int32,Ptr{Ptr{:RealType}},Ptr{:RealType},:Int32) shlib
+@c Int32 QRsol (:Int32,Ptr{Ptr{:RealType}},Ptr{:RealType},Ptr{:RealType}) shlib
 
 # header: /usr/local/include/sundials/sundials_math.h
-@c realtype RPowerI (:realtype,:Int32) shlib
-@c realtype RPowerR (:realtype,:realtype) shlib
-@c realtype RSqrt (:realtype,) shlib
-@c realtype RAbs (:realtype,) shlib
-@c realtype RExp (:realtype,) shlib
+@c RealType RPowerI (:RealType,:Int32) shlib
+@c RealType RPowerR (:RealType,:RealType) shlib
+@c RealType RSqrt (:RealType,) shlib
+@c RealType RAbs (:RealType,) shlib
+@c RealType RExp (:RealType,) shlib
 
 # header: /usr/local/include/sundials/sundials_nvector.h
 
@@ -104,22 +104,21 @@ const CLASSICAL_GS = 2
 @ctypedef SpbcgMemRec Void
 @ctypedef SpbcgMem Ptr{:Void}
 @c SpbcgMem SpbcgMalloc (:Int32,:N_Vector) shlib
-@c Int32 SpbcgSolve (:SpbcgMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:realtype,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:realtype},Ptr{:Int32},Ptr{:Int32}) shlib
+@c Int32 SpbcgSolve (:SpbcgMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:RealType,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:RealType},Ptr{:Int32},Ptr{:Int32}) shlib
 @c None SpbcgFree (:SpbcgMem,) shlib
 
 # header: /usr/local/include/sundials/sundials_spgmr.h
 @ctypedef SpgmrMemRec Void
 @ctypedef SpgmrMem Ptr{:Void}
 @c SpgmrMem SpgmrMalloc (:Int32,:N_Vector) shlib
-@c Int32 SpgmrSolve (:SpgmrMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:Int32,:realtype,:Int32,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:realtype},Ptr{:Int32},Ptr{:Int32}) shlib
+@c Int32 SpgmrSolve (:SpgmrMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:Int32,:RealType,:Int32,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:RealType},Ptr{:Int32},Ptr{:Int32}) shlib
 @c None SpgmrFree (:SpgmrMem,) shlib
 
 # header: /usr/local/include/sundials/sundials_sptfqmr.h
 @ctypedef SptfqmrMemRec Void
 @ctypedef SptfqmrMem Ptr{:Void}
 @c SptfqmrMem SptfqmrMalloc (:Int32,:N_Vector) shlib
-@c Int32 SptfqmrSolve (:SptfqmrMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:realtype,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:realtype},Ptr{:Int32},Ptr{:Int32}) shlib
+@c Int32 SptfqmrSolve (:SptfqmrMem,Ptr{:None},:N_Vector,:N_Vector,:Int32,:RealType,Ptr{:None},:N_Vector,:N_Vector,:ATimesFn,:PSolveFn,Ptr{:RealType},Ptr{:Int32},Ptr{:Int32}) shlib
 @c None SptfqmrFree (:SptfqmrMem,) shlib
 
 # header: /usr/local/include/sundials/sundials_types.h
-

--- a/src/nvector.jl
+++ b/src/nvector.jl
@@ -23,7 +23,7 @@ typealias N_Vector Ptr{NVECTOR_struct}
 
 
 # header: /usr/local/include/nvector/nvector_parallel.h
-@ctypedef realtype Float64
+@ctypedef RealType Float64
 @ctypedef N_Vector_Ops Ptr{:Void}
 # @ctypedef N_Vector Ptr{:Void}
 @ctypedef N_Vector_S Ptr{:N_Vector}
@@ -31,34 +31,34 @@ typealias N_Vector Ptr{NVECTOR_struct}
 @c N_Vector N_VCloneEmpty (:N_Vector,) shlib
 @c None N_VDestroy (:N_Vector,) shlib
 @c None N_VSpace (:N_Vector,Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:realtype} N_VGetArrayPointer (:N_Vector,) shlib
-@c None N_VSetArrayPointer (Ptr{:realtype},:N_Vector) shlib
-@c None N_VLinearSum (:realtype,:N_Vector,:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VConst (:realtype,:N_Vector) shlib
+@c Ptr{:RealType} N_VGetArrayPointer (:N_Vector,) shlib
+@c None N_VSetArrayPointer (Ptr{:RealType},:N_Vector) shlib
+@c None N_VLinearSum (:RealType,:N_Vector,:RealType,:N_Vector,:N_Vector) shlib
+@c None N_VConst (:RealType,:N_Vector) shlib
 @c None N_VProd (:N_Vector,:N_Vector,:N_Vector) shlib
 @c None N_VDiv (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VScale (:realtype,:N_Vector,:N_Vector) shlib
+@c None N_VScale (:RealType,:N_Vector,:N_Vector) shlib
 @c None N_VAbs (:N_Vector,:N_Vector) shlib
 @c None N_VInv (:N_Vector,:N_Vector) shlib
-@c None N_VAddConst (:N_Vector,:realtype,:N_Vector) shlib
-@c realtype N_VDotProd (:N_Vector,:N_Vector) shlib
-@c realtype N_VMaxNorm (:N_Vector,) shlib
-@c realtype N_VWrmsNorm (:N_Vector,:N_Vector) shlib
-@c realtype N_VWrmsNormMask (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMin (:N_Vector,) shlib
-@c realtype N_VWL2Norm (:N_Vector,:N_Vector) shlib
-@c realtype N_VL1Norm (:N_Vector,) shlib
-@c None N_VCompare (:realtype,:N_Vector,:N_Vector) shlib
+@c None N_VAddConst (:N_Vector,:RealType,:N_Vector) shlib
+@c RealType N_VDotProd (:N_Vector,:N_Vector) shlib
+@c RealType N_VMaxNorm (:N_Vector,) shlib
+@c RealType N_VWrmsNorm (:N_Vector,:N_Vector) shlib
+@c RealType N_VWrmsNormMask (:N_Vector,:N_Vector,:N_Vector) shlib
+@c RealType N_VMin (:N_Vector,) shlib
+@c RealType N_VWL2Norm (:N_Vector,:N_Vector) shlib
+@c RealType N_VL1Norm (:N_Vector,) shlib
+@c None N_VCompare (:RealType,:N_Vector,:N_Vector) shlib
 @c Int32 N_VInvTest (:N_Vector,:N_Vector) shlib
 @c Int32 N_VConstrMask (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMinQuotient (:N_Vector,:N_Vector) shlib
+@c RealType N_VMinQuotient (:N_Vector,:N_Vector) shlib
 @c Ptr{:N_Vector} N_VCloneEmptyVectorArray (:Int32,:N_Vector) shlib
 @c Ptr{:N_Vector} N_VCloneVectorArray (:Int32,:N_Vector) shlib
 @c None N_VDestroyVectorArray (Ptr{:N_Vector},:Int32) shlib
 @ctypedef N_VectorContent_Parallel Ptr{:Void}
 @c N_Vector N_VNew_Parallel (:Int32,:Clong,:Clong) shlib
 @c N_Vector N_VNewEmpty_Parallel (:Int32,:Clong,:Clong) shlib
-@c N_Vector N_VMake_Parallel (:Int32,:Clong,:Clong,Ptr{:realtype}) shlib
+@c N_Vector N_VMake_Parallel (:Int32,:Clong,:Clong,Ptr{:RealType}) shlib
 @c Ptr{:N_Vector} N_VCloneVectorArray_Parallel (:Int32,:N_Vector) shlib
 @c Ptr{:N_Vector} N_VCloneVectorArrayEmpty_Parallel (:Int32,:N_Vector) shlib
 @c None N_VDestroyVectorArray_Parallel (Ptr{:N_Vector},:Int32) shlib
@@ -67,33 +67,33 @@ typealias N_Vector Ptr{NVECTOR_struct}
 @c N_Vector N_VClone_Parallel (:N_Vector,) shlib
 @c None N_VDestroy_Parallel (:N_Vector,) shlib
 @c None N_VSpace_Parallel (:N_Vector,Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:realtype} N_VGetArrayPointer_Parallel (:N_Vector,) shlib
-@c None N_VSetArrayPointer_Parallel (Ptr{:realtype},:N_Vector) shlib
-@c None N_VLinearSum_Parallel (:realtype,:N_Vector,:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VConst_Parallel (:realtype,:N_Vector) shlib
+@c Ptr{:RealType} N_VGetArrayPointer_Parallel (:N_Vector,) shlib
+@c None N_VSetArrayPointer_Parallel (Ptr{:RealType},:N_Vector) shlib
+@c None N_VLinearSum_Parallel (:RealType,:N_Vector,:RealType,:N_Vector,:N_Vector) shlib
+@c None N_VConst_Parallel (:RealType,:N_Vector) shlib
 @c None N_VProd_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
 @c None N_VDiv_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VScale_Parallel (:realtype,:N_Vector,:N_Vector) shlib
+@c None N_VScale_Parallel (:RealType,:N_Vector,:N_Vector) shlib
 @c None N_VAbs_Parallel (:N_Vector,:N_Vector) shlib
 @c None N_VInv_Parallel (:N_Vector,:N_Vector) shlib
-@c None N_VAddConst_Parallel (:N_Vector,:realtype,:N_Vector) shlib
-@c realtype N_VDotProd_Parallel (:N_Vector,:N_Vector) shlib
-@c realtype N_VMaxNorm_Parallel (:N_Vector,) shlib
-@c realtype N_VWrmsNorm_Parallel (:N_Vector,:N_Vector) shlib
-@c realtype N_VWrmsNormMask_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMin_Parallel (:N_Vector,) shlib
-@c realtype N_VWL2Norm_Parallel (:N_Vector,:N_Vector) shlib
-@c realtype N_VL1Norm_Parallel (:N_Vector,) shlib
-@c None N_VCompare_Parallel (:realtype,:N_Vector,:N_Vector) shlib
+@c None N_VAddConst_Parallel (:N_Vector,:RealType,:N_Vector) shlib
+@c RealType N_VDotProd_Parallel (:N_Vector,:N_Vector) shlib
+@c RealType N_VMaxNorm_Parallel (:N_Vector,) shlib
+@c RealType N_VWrmsNorm_Parallel (:N_Vector,:N_Vector) shlib
+@c RealType N_VWrmsNormMask_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
+@c RealType N_VMin_Parallel (:N_Vector,) shlib
+@c RealType N_VWL2Norm_Parallel (:N_Vector,:N_Vector) shlib
+@c RealType N_VL1Norm_Parallel (:N_Vector,) shlib
+@c None N_VCompare_Parallel (:RealType,:N_Vector,:N_Vector) shlib
 @c Int32 N_VInvTest_Parallel (:N_Vector,:N_Vector) shlib
 @c Int32 N_VConstrMask_Parallel (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMinQuotient_Parallel (:N_Vector,:N_Vector) shlib
+@c RealType N_VMinQuotient_Parallel (:N_Vector,:N_Vector) shlib
 
 # header: /usr/local/include/nvector/nvector_serial.h
 @ctypedef N_VectorContent_Serial Ptr{:Void}
 @c N_Vector N_VNew_Serial (:Clong,) shlib
 @c N_Vector N_VNewEmpty_Serial (:Clong,) shlib
-@c N_Vector N_VMake_Serial (:Clong,Ptr{:realtype}) shlib
+@c N_Vector N_VMake_Serial (:Clong,Ptr{:RealType}) shlib
 @c Ptr{:N_Vector} N_VCloneVectorArray_Serial (:Int32,:N_Vector) shlib
 @c Ptr{:N_Vector} N_VCloneVectorArrayEmpty_Serial (:Int32,:N_Vector) shlib
 @c None N_VDestroyVectorArray_Serial (Ptr{:N_Vector},:Int32) shlib
@@ -102,24 +102,24 @@ typealias N_Vector Ptr{NVECTOR_struct}
 @c N_Vector N_VClone_Serial (:N_Vector,) shlib
 @c None N_VDestroy_Serial (:N_Vector,) shlib
 @c None N_VSpace_Serial (:N_Vector,Ptr{:Clong},Ptr{:Clong}) shlib
-@c Ptr{:realtype} N_VGetArrayPointer_Serial (:N_Vector,) shlib
-@c None N_VSetArrayPointer_Serial (Ptr{:realtype},:N_Vector) shlib
-@c None N_VLinearSum_Serial (:realtype,:N_Vector,:realtype,:N_Vector,:N_Vector) shlib
-@c None N_VConst_Serial (:realtype,:N_Vector) shlib
+@c Ptr{:RealType} N_VGetArrayPointer_Serial (:N_Vector,) shlib
+@c None N_VSetArrayPointer_Serial (Ptr{:RealType},:N_Vector) shlib
+@c None N_VLinearSum_Serial (:RealType,:N_Vector,:RealType,:N_Vector,:N_Vector) shlib
+@c None N_VConst_Serial (:RealType,:N_Vector) shlib
 @c None N_VProd_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
 @c None N_VDiv_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c None N_VScale_Serial (:realtype,:N_Vector,:N_Vector) shlib
+@c None N_VScale_Serial (:RealType,:N_Vector,:N_Vector) shlib
 @c None N_VAbs_Serial (:N_Vector,:N_Vector) shlib
 @c None N_VInv_Serial (:N_Vector,:N_Vector) shlib
-@c None N_VAddConst_Serial (:N_Vector,:realtype,:N_Vector) shlib
-@c realtype N_VDotProd_Serial (:N_Vector,:N_Vector) shlib
-@c realtype N_VMaxNorm_Serial (:N_Vector,) shlib
-@c realtype N_VWrmsNorm_Serial (:N_Vector,:N_Vector) shlib
-@c realtype N_VWrmsNormMask_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMin_Serial (:N_Vector,) shlib
-@c realtype N_VWL2Norm_Serial (:N_Vector,:N_Vector) shlib
-@c realtype N_VL1Norm_Serial (:N_Vector,) shlib
-@c None N_VCompare_Serial (:realtype,:N_Vector,:N_Vector) shlib
+@c None N_VAddConst_Serial (:N_Vector,:RealType,:N_Vector) shlib
+@c RealType N_VDotProd_Serial (:N_Vector,:N_Vector) shlib
+@c RealType N_VMaxNorm_Serial (:N_Vector,) shlib
+@c RealType N_VWrmsNorm_Serial (:N_Vector,:N_Vector) shlib
+@c RealType N_VWrmsNormMask_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
+@c RealType N_VMin_Serial (:N_Vector,) shlib
+@c RealType N_VWL2Norm_Serial (:N_Vector,:N_Vector) shlib
+@c RealType N_VL1Norm_Serial (:N_Vector,) shlib
+@c None N_VCompare_Serial (:RealType,:N_Vector,:N_Vector) shlib
 @c Int32 N_VInvTest_Serial (:N_Vector,:N_Vector) shlib
 @c Int32 N_VConstrMask_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
-@c realtype N_VMinQuotient_Serial (:N_Vector,:N_Vector) shlib
+@c RealType N_VMinQuotient_Serial (:N_Vector,:N_Vector) shlib

--- a/src/nvector.jl
+++ b/src/nvector.jl
@@ -1,5 +1,5 @@
 
-recurs_sym_type(ex::Any) = 
+recurs_sym_type(ex::Any) =
   (ex==None || typeof(ex)==Symbol || length(ex.args)==1) ? eval(ex) : Expr(ex.head, ex.args[1], recurs_sym_type(ex.args[2]))
 macro c(ret_type, func, arg_types, lib)
   local _arg_types = Expr(:tuple, [recurs_sym_type(a) for a in arg_types.args]...)
@@ -18,10 +18,14 @@ macro ctypedef(fake_t,real_t)
   end
 end
 
+type NVECTOR_struct; end # dummy type to give us a typed pointer
+typealias N_Vector Ptr{NVECTOR_struct}
+
+
 # header: /usr/local/include/nvector/nvector_parallel.h
 @ctypedef realtype Float64
 @ctypedef N_Vector_Ops Ptr{:Void}
-@ctypedef N_Vector Ptr{:Void}
+# @ctypedef N_Vector Ptr{:Void}
 @ctypedef N_Vector_S Ptr{:N_Vector}
 @c N_Vector N_VClone (:N_Vector,) shlib
 @c N_Vector N_VCloneEmpty (:N_Vector,) shlib
@@ -119,4 +123,3 @@ end
 @c Int32 N_VInvTest_Serial (:N_Vector,:N_Vector) shlib
 @c Int32 N_VConstrMask_Serial (:N_Vector,:N_Vector,:N_Vector) shlib
 @c realtype N_VMinQuotient_Serial (:N_Vector,:N_Vector) shlib
-


### PR DESCRIPTION
I started to implement the suggestion @stevengj gave in #26. There are new types `KinsolHandle`, `CVodeHandle`, `IdaHandle` and `NVector` with finalizers. I hope this doesn't break any existing code which doesn't use the simplified interface? IDAS and CVodes are not covered yet.