### PR TITLE
WIP: Add inplace version of cvode

### DIFF
--- a/src/simple.jl
+++ b/src/simple.jl
@@ -97,12 +97,12 @@ end
 return: a solution matrix with time steps in `t` along rows and
         state variable `y` along columns
 """
-cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
+cvode(f::Function, y0::Vector{Float64}, t::AbstractVector, userdata::Any=nothing;
                 integrator=:BDF, reltol::Float64=1e-3, abstol::Float64=1e-6) = 
     cvode!(f, y0, t, zeros(length(t), length(y0)), userdata; 
                     integrator=integrator, reltol=reltol, abstol=abstol)
 
-function cvode!(f::Function, y0::Vector{Float64}, t::Vector{Float64}, y::Matrix{Float64}, userdata::Any=nothing;
+function cvode!(f::Function, y0::Vector{Float64}, t::AbstractVector, y::Matrix{Float64}, userdata::Any=nothing;
                 integrator=:BDF, reltol::Float64=1e-3, abstol::Float64=1e-6)
     if integrator==:BDF
         mem = CVodeCreate(CV_BDF, CV_NEWTON)


### PR DESCRIPTION
Hi all, 

Due to the recent activity on this package I decided to scratch a few itches...

In my code I somehow have already allocated the output where I want to store the solution of some differential equation. This PR adds a method `cvode!` that accept an input matrix where the solution can be stored. There is also the usual method `cvode` that allocates the output in case it is needed.

Also, I could not resist relaxing the typing for the time vector. So many times I have `t` as a `FloatRange` or a `linspace`...

Could anyone explain the historical reason why we store samples of the solution along rows of the output and not along columns in an array of transposed sizes? 
