### PR TITLE
Fix README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ function f(t, y, ydot)
     ydot[2] = -ydot[1] - ydot[3]
 end
 
-t = [0.0, 4 * logspace(-1., 7., 9)]
+t = [0.0; 4 * logspace(-1., 7., 9)]
 res = Sundials.cvode(f, [1.0, 0.0, 0.0], t)
 ```
 


### PR DESCRIPTION
v0.5 now will concatenate the types given in `[]`, so `t = [0.0; 4 * logspace(-1., 7., 9)]` gives an `Array{Float64,1}` while the previous example (with a `,`) no longer does. This fixes the example which was noticed as incorrect in the most recent version in #84