### PR TITLE
Implement API Changes from #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ t = [0.0; 4 * logspace(-1., 7., 9)]
 res = Sundials.cvode(f, [1.0, 0.0, 0.0], t)
 ```
 
-For `cvode`, there is an optional positional argument `integrator` to choose
+For `cvode`, there is a keyword argument `integrator` to choose
 between the two provided integration options: `:BDF` for a Backwards Differentiation
 Formula method and `:Adams` for an Adams-Moulton method. There are two supported
 keyword arguments, `reltol`, and `abstol`, for `cvode` and `idasol`. For more

--- a/examples/cvode_Roberts_simplified.jl
+++ b/examples/cvode_Roberts_simplified.jl
@@ -11,6 +11,6 @@ end
 
 const t = [0.0; 4 * logspace(-1., 7., 9)]
 const y0 = [1.0, 0.0, 0.0]
-res = Sundials.cvode(f, y0, t)
+ts,res = Sundials.cvode(f, y0, t)
 
-ts1, res3 = Sundials.cvode_fulloutput(f, y0, [0.0, 1.0])
+ts1, res3 = Sundials.cvode(f, y0, [0.0, 1.0],collect_times=:all)

--- a/examples/cvode_Roberts_simplified.jl
+++ b/examples/cvode_Roberts_simplified.jl
@@ -12,5 +12,4 @@ end
 const t = [0.0; 4 * logspace(-1., 7., 9)]
 const y0 = [1.0, 0.0, 0.0]
 ts,res = Sundials.cvode(f, y0, t)
-
-ts1,res3 = Sundials.cvode(f, y0, [0.0, 1.0],collect_times=:all)
+ts2,res2 = Sundials.cvode(f, y0, [0.0;4.0;40.0],collect_times=:all)

--- a/examples/cvode_Roberts_simplified.jl
+++ b/examples/cvode_Roberts_simplified.jl
@@ -10,6 +10,31 @@ function f(t, y, ydot)
 end
 
 const t = [0.0; 4 * logspace(-1., 7., 9)]
+const shortt = [0.0;4.0;40.0]
 const y0 = [1.0, 0.0, 0.0]
+
+# Test out-of-place versions
 ts,res = Sundials.cvode(f, y0, t)
-ts2,res2 = Sundials.cvode(f, y0, [0.0;4.0;40.0],collect_times=:all)
+ts2,res2 = Sundials.cvode(f, y0, t,Val{false})
+ts3,res3 = Sundials.cvode(f, y0,shortt,Val{false},collect_times=:all)
+
+# Test in-place versions
+res4 = Matrix{Float64}(length(t),length(y0))
+ts4 = copy(t)
+Sundials.cvode!(f, y0,ts4,res4)
+
+res5 = Vector{Vector{Float64}}(length(t))
+for i in 1:length(t)
+  res5[i] = Vector{Float64}(length(y0))
+end
+ts5 = copy(t)
+Sundials.cvode!(f, y0,ts5,res5)
+
+ts3,res3 = Sundials.cvode(f, y0,shortt,Val{false},collect_times=:all)
+
+res6 = Vector{Vector{Float64}}(length(shortt))
+for i in 1:length(shortt)
+  res6[i] = Vector{Float64}(length(y0))
+end
+ts6 = copy(shortt)
+Sundials.cvode!(f, y0,ts6,res6;collect_times=:all)

--- a/examples/cvode_Roberts_simplified.jl
+++ b/examples/cvode_Roberts_simplified.jl
@@ -13,4 +13,4 @@ const t = [0.0; 4 * logspace(-1., 7., 9)]
 const y0 = [1.0, 0.0, 0.0]
 ts,res = Sundials.cvode(f, y0, t)
 
-ts1, res3 = Sundials.cvode(f, y0, [0.0, 1.0],collect_times=:all)
+ts1,res3 = Sundials.cvode(f, y0, [0.0, 1.0],collect_times=:all)

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -108,6 +108,7 @@ function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
                userdata::Any = nothing;
                collect_times::Symbol=:specified,integrator::Symbol=:BDF,
                reltol::Float64=1e-3, abstol::Float64=1e-6)
+
     t0 = tspan[1]
     Ts = tspan[2:end]
     if integrator==:BDF
@@ -136,19 +137,20 @@ function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
           for t in Ts
               while tout[end] < t
                   flag = @checkflag CVode(mem, t, ynv, tout, CV_ONE_STEP)
-                  push!(yres,convert(Vector,copy(ynv)))
+                  y = convert(Vector,ynv)
+                  push!(yres,copy(y))
                   push!(ts, tout...)
               end
               # Fix the end
-              flag = @checkflag CVodeGetDky(mem, t, Cint(0), yres[end])
+              flag = @checkflag CVodeGetDky(mem, t, Cint(0), NVector(yres[end]))
               ts[end] = t
           end
 
         elseif collect_times == :specified
+          ts = Ts
           for t in Ts
             flag = @checkflag CVode(mem, t, ynv, tout, CV_NORMAL)
             push!(yres,convert(Vector,copy(ynv)))
-            push!(ts, tout...)
           end
         end
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -21,26 +21,26 @@ macro checkflag(ex)
 end
 
 type UserFunctionAndData
-    func::Function
+    func::Base.Callable
     data::Any
 
-    UserFunctionAndData(func::Function, data::Any) = new(func, data)
+    UserFunctionAndData(func::Base.Callable, data::Any) = new(func, data)
 end
 
-UserFunctionAndData(func::Function) = func
-UserFunctionAndData(func::Function, data::Void) = func
+UserFunctionAndData(func::Base.Callable) = func
+UserFunctionAndData(func::Base.Callable, data::Void) = func
 
 function kinsolfun(y::N_Vector, fy::N_Vector, userfun::UserFunctionAndData)
     userfun[].func(convert(Vector, y), convert(Vector, fy), userfun[].data)
     return KIN_SUCCESS
 end
 
-function kinsolfun(y::N_Vector, fy::N_Vector, userfun::Function)
+function kinsolfun(y::N_Vector, fy::N_Vector, userfun::Base.Callable)
     userfun(convert(Vector, y), convert(Vector, fy))
     return KIN_SUCCESS
 end
 
-function kinsol(f::Function, y0::Vector{Float64}, userdata::Any = nothing)
+function kinsol(f::Base.Callable, y0::Vector{Float64}, userdata::Any = nothing)
     # f, Function to be optimized of the form f(y::Vector{Float64}, fy::Vector{Float64})
     #    where `y` is the input vector, and `fy` is the result of the function
     # y0, Vector of initial values
@@ -74,13 +74,13 @@ function cvodefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::UserFunctionAn
     return CV_SUCCESS
 end
 
-function cvodefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::Function)
+function cvodefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::Base.Callable)
     userfun(t, convert(Vector, y), convert(Vector, yp))
     return CV_SUCCESS
 end
 
 """
-`cvode(f::Function, y0::Vector{Float64},
+`cvode(f::Base.Callable, y0::Vector{Float64},
        tspan::Vector{Float64}, userdata::Any = nothing,::Type{Val{Bool}};
        collect_times::Symbol=:specified,integrator=:BDF,
        reltol::Float64=DEFAULT_RELTOL, abstol::Float64=DEFAULT_ABSTOL)`
@@ -109,7 +109,7 @@ Output type is set by specifying the Val type.
 
 return: `(t,y)`: `t` are the timepoints and `y` are the values.
 """
-function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
+function cvode(f::Base.Callable, y0::AbstractVector, tspan::AbstractVector,
                userdata::Any = nothing;
                collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -123,7 +123,7 @@ function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
          abstol=abstol)
 end
 
-function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
+function cvode(f::Base.Callable, y0::AbstractVector, tspan::AbstractVector,
                ::Type{Val{false}},userdata::Any = nothing;
                collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -141,7 +141,7 @@ function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
     return t,y
 end
 
-function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
+function cvode(f::Base.Callable, y0::AbstractVector, tspan::AbstractVector,
                ::Type{Val{true}},userdata::Any = nothing;
                collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -155,7 +155,7 @@ function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
     return t,y
 end
 
-function cvode!(f::Function, y0::AbstractVector, tspan::AbstractVector,
+function cvode!(f::Base.Callable, y0::AbstractVector, tspan::AbstractVector,
                 y_mat::Matrix{Float64},userdata = nothing;
                 collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                 integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -177,7 +177,7 @@ function cvode!(f::Function, y0::AbstractVector, tspan::AbstractVector,
     nothing
 end
 
-function cvode!(f::Function, y0::AbstractVector, tspan::AbstractVector,
+function cvode!(f::Base.Callable, y0::AbstractVector, tspan::AbstractVector,
                 y::AbstractVector,userdata::Any = nothing;
                 collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                 integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -248,13 +248,13 @@ function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::
     return IDA_SUCCESS
 end
 
-function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::Function)
+function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::Base.Callable)
     userfun(t, convert(Vector, y), convert(Vector, yp), convert(Vector, r))
     return IDA_SUCCESS
 end
 
 """
-`idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
+`idasol(f::Base.Callable, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
         reltol::Float64=DEFAULT_RELTOL, abstol::Float64=DEFAULT_ABSTOL, diffstates::Union{Vector{Bool},Void}=nothing)`
 
 * `f`, Function of the form
@@ -270,7 +270,7 @@ end
 return: (y,yp) two solution matrices representing the states and state derivatives
          with time steps in `t` along rows and state variable `y` or `yp` along columns
 """
-function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
+function idasol(f::Base.Callable, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                 reltol::Float64=DEFAULT_RELTOL, abstol::Float64=DEFAULT_ABSTOL, diffstates::Union{Vector{Bool},Void}=nothing)
     mem = IDACreate()
     if mem == C_NULL

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -109,7 +109,7 @@ Output type is set by specifying the Val type.
 
 return: `(t,y)`: `t` are the timepoints and `y` are the values.
 """
-function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
+function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
                userdata::Any = nothing;
                collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -123,7 +123,7 @@ function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
          abstol=abstol)
 end
 
-function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
+function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
                ::Type{Val{false}},userdata::Any = nothing;
                collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -141,7 +141,7 @@ function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
     return t,y
 end
 
-function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
+function cvode(f::Function, y0::AbstractVector, tspan::AbstractVector,
                ::Type{Val{true}},userdata::Any = nothing;
                collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -155,7 +155,7 @@ function cvode(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
     return t,y
 end
 
-function cvode!(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
+function cvode!(f::Function, y0::AbstractVector, tspan::AbstractVector,
                 y_mat::Matrix{Float64},userdata = nothing;
                 collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                 integrator::Symbol=DEFAULT_INTEGRATOR,
@@ -177,7 +177,7 @@ function cvode!(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
     nothing
 end
 
-function cvode!(f::Function, y0::Vector{Float64}, tspan::Vector{Float64},
+function cvode!(f::Function, y0::AbstractVector, tspan::AbstractVector,
                 y::AbstractVector,userdata::Any = nothing;
                 collect_times::Symbol=DEFAULT_COLLECT_TIMES,
                 integrator::Symbol=DEFAULT_INTEGRATOR,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,10 @@ examples_path = joinpath(dirname(@__FILE__), "..", "examples")
 println("== start cvode Roberts example (simplified)")
 let
 include(joinpath(examples_path, "cvode_Roberts_simplified.jl"))
+
+@test_approx_eq ts2[35] ts[3]  # Should be the same due to intermediate stepping
+@test_approx_eq_eps res2[35] res[3] 1e-4 # Should interpolate the same
+
 println("result at t=$(t[end]):")
 println(res[:,end], "\n")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,38 +6,41 @@ examples_path = joinpath(dirname(@__FILE__), "..", "examples")
 # run cvode example
 println("== start cvode Roberts example (simplified)")
 let
-include(joinpath(examples_path, "cvode_Roberts_simplified.jl"))
+    include(joinpath(examples_path, "cvode_Roberts_simplified.jl"))
 
-@test_approx_eq ts2[35] ts[3]  # Should be the same due to intermediate stepping
-@test_approx_eq_eps res2[35] res[3] 1e-4 # Should interpolate the same
-
-println("result at t=$(t[end]):")
-println(res[:,end], "\n")
+    @test_approx_eq ts3[35] ts2[3]  # Should be the same due to intermediate stepping
+    @test_approx_eq_eps res3[35] res2[3] 1e-4 # Should interpolate the same
+    @test res4 == res # In-place output shoudl be the same
+    @test res5 == res2
+    @test_approx_eq res6[35] res3[35]
+    @test res6 == res3
+    println("result at t=$(t[end]):")
+    println(res[:,end], "\n")
 end
 
 println("== start cvode Roberts example")
 let
-include(joinpath(examples_path, "cvode_Roberts_dns.jl"))
+    include(joinpath(examples_path, "cvode_Roberts_dns.jl"))
 end
 
 # run ida examples
 println("== start ida_Roberts example (simplified)")
 let
-include(joinpath(examples_path, "ida_Roberts_simplified.jl"))
+    include(joinpath(examples_path, "ida_Roberts_simplified.jl"))
 end
 
 println("== start ida_Roberts example")
 let
-include(joinpath(examples_path, "ida_Roberts_dns.jl"))
-println("result at t=$(t[end]):")
-println(yout[:,end], "\n")
+    include(joinpath(examples_path, "ida_Roberts_dns.jl"))
+    println("result at t=$(t[end]):")
+    println(yout[:,end], "\n")
 end
 
 println("== start ida_Heat2D example")
 let
-include(joinpath(examples_path, "ida_Heat2D.jl"))
-println("result at t=$(t[end]):")
-println(yout[:,end], "\n")
+    include(joinpath(examples_path, "ida_Heat2D.jl"))
+    println("result at t=$(t[end]):")
+    println(yout[:,end], "\n")
 end
 
 #= requires Grid package
@@ -50,17 +53,17 @@ end
 # run kinsol example
 println("== start kinsol example (simplified)")
 let
-include(joinpath(examples_path, "kinsol_mkin_simplified.jl"))
-println("solution:")
-println(res)
-residual = ones(2)
-sysfn(res, residual)
-println("residual:")
-println(residual, "\n")
+    include(joinpath(examples_path, "kinsol_mkin_simplified.jl"))
+    println("solution:")
+    println(res)
+    residual = ones(2)
+    sysfn(res, residual)
+    println("residual:")
+    println(residual, "\n")
 end
 
 println("== start kinsol example")
 let
-include(joinpath(examples_path, "kinsol_mkinTest.jl"))
-@test abs(minimum(residual)) < 1e-5
+    include(joinpath(examples_path, "kinsol_mkinTest.jl"))
+    @test abs(minimum(residual)) < 1e-5
 end


### PR DESCRIPTION
This implements the changes suggested in #75. The parts of the design to note are:
- A value type is used to dispatch for matrices and `Vector{Vector}` output. This makes both available yet it's type stable. Default to matrix output for now.
- Added in-place version like #76.
- Note that the only combination not allowed is matrix output + `collect_times=:all` since internally it's only `Vector{Vector}` and making it append views of the right `SubArray` is an unnecessary difficulty.
- Output matrix has the ith column be the timeseries of the ith component. I believe this is the transpose wished for in #76.
