### PR TITLE
Drop v0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.4
     - 0.5
     - nightly
 notifications:
@@ -13,4 +12,3 @@ notifications:
 #    - julia -e 'Pkg.clone(pwd()); Pkg.build("Sundials"); Pkg.test("Sundials"; coverage=true)';
 after_success:
     - julia -e 'cd(Pkg.dir("Sundials")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5
 BinDeps 0.3
 Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 


### PR DESCRIPTION
Drop v0.4 in tests, and require v0.5. This will be required for using views. Note that this means that people on previous versions when using `Pkg.add` will get the last release before this release. I think this is sensible for such a large change: people looking for backwards compatibility likely won't want such a large change dropping in.
