### PR TITLE
Move algs to Sundials

### DIFF
--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -12,7 +12,7 @@ else
     error("Sundials is not properly installed. Please run Pkg.build(\"Sundials\")")
 end
 
-export solve
+export solve, SundialsAlgorithm, CVODE_BDF, CVODE_Adams
 
 # some definitions from the system C headers wrapped into the types_and_consts.jl
 const DBL_MAX = prevfloat(Inf)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,3 +1,9 @@
+# Sundials.jl algorithms
+
+abstract SundialsAlgorithm <: AbstractODEAlgorithm
+immutable CVODE_BDF <: SundialsAlgorithm end
+immutable CVODE_Adams <: SundialsAlgorithm end
+
 function solve{uType,tType,isinplace,algType<:SundialsAlgorithm,F}(
     prob::AbstractODEProblem{uType,tType,isinplace,F},
     alg::Type{algType},timeseries=[],ts=[],ks=[];


### PR DESCRIPTION
This change is in conjunction with https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/5, moving the Sundials algorithms out of DiffEqBase and to here. @mauro3