### PR TITLE
Add IDA to the common interface

### DIFF
--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -1,4 +1,4 @@
-using DiffEqProblemLibrary, DiffEqBase
+using DiffEqProblemLibrary, DiffEqBase, Sundials
 
 prob = prob_ode_linear
 dt = 1//2^(4)
@@ -27,3 +27,12 @@ u0 = [1.0 2.0
       3.0 2.0]
 prob = ODEProblem(h,u0,(0.0,1.0))
 @time sol = solve(prob,CVODE_BDF)
+
+prob = prob_dae_resrob
+dt = 1000
+saveat = float(collect(0:dt:100000))
+sol = solve(prob,IDA)
+sol = solve(prob,IDA,saveat=saveat)
+bool5 = intersect(sol.t,saveat) == saveat
+sol = solve(prob,IDA,saveat=saveat,save_timeseries=false)
+bool6 = sol.t == saveat

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -12,7 +12,7 @@ else
     error("Sundials is not properly installed. Please run Pkg.build(\"Sundials\")")
 end
 
-export solve, SundialsAlgorithm, CVODE_BDF, CVODE_Adams
+export solve, SundialsODEAlgorithm, SundialsDAEAlgorithm, CVODE_BDF, CVODE_Adams, IDA
 
 # some definitions from the system C headers wrapped into the types_and_consts.jl
 const DBL_MAX = prevfloat(Inf)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,10 +1,12 @@
 # Sundials.jl algorithms
 
-abstract SundialsAlgorithm <: AbstractODEAlgorithm
-immutable CVODE_BDF <: SundialsAlgorithm end
-immutable CVODE_Adams <: SundialsAlgorithm end
+abstract SundialsODEAlgorithm <: AbstractODEAlgorithm
+abstract SundialsDAEAlgorithm <: AbstractDAEAlgorithm
+immutable CVODE_BDF <: SundialsODEAlgorithm end
+immutable CVODE_Adams <: SundialsODEAlgorithm end
+immutable IDA <: SundialsDAEAlgorithm end
 
-function solve{uType,tType,isinplace,algType<:SundialsAlgorithm,F}(
+function solve{uType,tType,isinplace,algType<:SundialsODEAlgorithm,F}(
     prob::AbstractODEProblem{uType,tType,isinplace,F},
     alg::Type{algType},timeseries=[],ts=[],ks=[];
     callback=()->nothing,abstol=1/10^6,reltol=1/10^3,
@@ -71,7 +73,6 @@ function solve{uType,tType,isinplace,algType<:SundialsAlgorithm,F}(
         flag = @checkflag CVodeSetMaxNumSteps(mem, maxiter)
         flag = @checkflag CVDense(mem, length(u0))
         push!(ures, copy(u0))
-        u = NVector(copy(u0))
         utmp = NVector(copy(u0))
         tout = [0.0]
 
@@ -82,8 +83,8 @@ function solve{uType,tType,isinplace,algType<:SundialsAlgorithm,F}(
                 while tout[end] < save_ts[k]
                     looped = true
                     flag = @checkflag CVode(mem,
-                                    save_ts[k], u, tout, CV_ONE_STEP)
-                    push!(ures,copy(u))
+                                    save_ts[k], utmp, tout, CV_ONE_STEP)
+                    push!(ures,copy(utmp))
                     push!(ts, tout...)
                 end
                 if looped
@@ -93,8 +94,8 @@ function solve{uType,tType,isinplace,algType<:SundialsAlgorithm,F}(
                     ts[end] = save_ts[k]
                 else # Just push another value
                     flag = @checkflag CVodeGetDky(
-                                            mem, save_ts[k], Cint(0), ures[end])
-                    push!(ures,copy(u))
+                                            mem, save_ts[k], Cint(0), utmp)
+                    push!(ures,copy(utmp))
                     push!(ts, save_ts[k]...)
                 end
             end
@@ -123,6 +124,145 @@ function solve{uType,tType,isinplace,algType<:SundialsAlgorithm,F}(
         end
     end
 
-    build_ode_solution(prob,alg,ts,timeseries,
+    build_solution(prob,alg,ts,timeseries,
+                      timeseries_errors = timeseries_errors)
+end
+
+## Solve for DAEs uses IDA
+
+function solve{uType,duType,tType,isinplace,algType<:SundialsDAEAlgorithm,F}(
+    prob::AbstractDAEProblem{uType,duType,tType,isinplace,F},
+    alg::Type{algType},timeseries=[],ts=[],ks=[];
+    callback=()->nothing,abstol=1/10^6,reltol=1/10^3,
+    saveat=Float64[],adaptive=true,maxiter=Int(1e5),
+    timeseries_errors=true,save_timeseries=true,
+    userdata=nothing,kwargs...)
+
+    tspan = prob.tspan
+    t0 = tspan[1]
+    T = tspan[end]
+
+    save_ts = sort(unique([t0;saveat;T]))
+
+    if T < save_ts[end]
+        error("Final saving timepoint is past the solving timespan")
+    end
+    if t0 > save_ts[1]
+        error("First saving timepoint is before the solving timespan")
+    end
+
+    if typeof(prob.u0) <: Number
+        u0 = [prob.u0]
+    else
+        u0 = vec(deepcopy(prob.u0))
+    end
+
+    if typeof(prob.du0) <: Number
+        du0 = [prob.du0]
+    else
+        du0 = vec(deepcopy(prob.du0))
+    end
+
+    sizeu = size(prob.u0)
+    sizedu = size(prob.du0)
+
+    ### Fix the more general function to Sundials allowed style
+    if !isinplace && (typeof(prob.u0)<:Vector{Float64} || typeof(prob.u0)<:Number)
+        f! = (t,u,du,out) -> (out[:] = prob.f(t,u,du); 0)
+    elseif !isinplace && typeof(prob.u0)<:AbstractArray
+        f! = (t,u,du,out) -> (out[:] = vec(prob.f(t,reshape(u,sizeu),reshape(du,sizedu))); 0)
+    elseif typeof(prob.u0)<:Vector{Float64}
+        f! = prob.f
+    else # Then it's an in-place function on an abstract array
+        f! = (t,u,du,out) -> (prob.f(t,reshape(u,sizeu),reshape(du,sizedu),out);
+                          u = vec(u); du=vec(du); 0)
+    end
+
+    mem = IDACreate()
+    if mem == C_NULL
+        error("Failed to allocate IDA solver object")
+    end
+
+    ures = Vector{Vector{Float64}}()
+    ts   = [t0]
+
+    try
+        userfun = UserFunctionAndData(f!, userdata)
+        u0nv = NVector(u0)
+        flag = @checkflag IDAInit(mem, cfunction(idasolfun,
+                                  Cint, (realtype, N_Vector, N_Vector,
+                                  N_Vector, Ref{typeof(userfun)})),
+                                  t0, convert(N_Vector, u0),
+                                  convert(N_Vector, du0))
+        flag = @checkflag IDASetUserData(mem, userfun)
+        flag = @checkflag IDASStolerances(mem, reltol, abstol)
+        flag = @checkflag IDASetMaxNumSteps(mem, maxiter)
+        flag = @checkflag IDADense(mem, length(u0))
+
+        push!(ures, copy(u0))
+        utmp = NVector(copy(u0))
+        dutmp = NVector(copy(u0))
+        tout = [0.0]
+
+        rtest = zeros(length(u0))
+        f!(t0, u0, du0, rtest)
+        if any(abs(rtest) .>= reltol)
+            if diffstates === nothing
+                error("Must supply diffstates argument to use IDA initial value solver.")
+            end
+            flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
+            flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[2])
+        end
+
+        # The Inner Loops : Style depends on save_timeseries
+        if save_timeseries
+            for k in 2:length(save_ts)
+                looped = false
+                while tout[end] < save_ts[k]
+                    looped = true
+                    flag = @checkflag IDASolve(mem,
+                                    save_ts[k], tout, utmp, dutmp, IDA_ONE_STEP)
+
+                    push!(ures,copy(utmp))
+                    push!(ts, tout...)
+                end
+                if looped
+                    # Fix the end
+                    flag = @checkflag IDAGetDky(
+                                            mem, save_ts[k], Cint(0), ures[end])
+                    ts[end] = save_ts[k]
+                else # Just push another value
+                    flag = @checkflag IDAGetDky(
+                                            mem, save_ts[k], Cint(0), utmp)
+                    push!(ures,copy(utmp))
+                    push!(ts, save_ts[k]...)
+                end
+            end
+        else # save_timeseries == false, so use IDA_NORMAL style
+            for k in 2:length(save_ts)
+                flag = @checkflag IDASolve(mem,
+                                    save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
+                push!(ures,copy(utmp))
+            end
+            ts = save_ts
+        end
+    finally
+        IDAFree(Ref{IDAMemPtr}(mem))
+    end
+
+    ### Finishing Routine
+
+    timeseries = Vector{uType}(0)
+    if typeof(prob.u0)<:Number
+        for i=1:length(ures)
+            push!(timeseries,ures[i][1])
+        end
+    else
+        for i=1:length(ures)
+            push!(timeseries,reshape(ures[i],sizeu))
+        end
+    end
+
+    build_solution(prob,alg,ts,timeseries,
                       timeseries_errors = timeseries_errors)
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -206,7 +206,7 @@ function solve{uType,duType,tType,isinplace,algType<:SundialsDAEAlgorithm,F}(
 
         rtest = zeros(length(u0))
         f!(t0, u0, du0, rtest)
-        if any(abs(rtest) .>= reltol)
+        if any(abs.(rtest) .>= reltol)
             if diffstates === nothing
                 error("Must supply diffstates argument to use IDA initial value solver.")
             end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -97,7 +97,7 @@ end
 return: a solution matrix with time steps in `t` along rows and
         state variable `y` along columns
 """
-function cvode(f::Function, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
+function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
               integrator=:BDF, reltol::Float64=1e-3, abstol::Float64=1e-6)
     if integrator==:BDF
         mem = CVodeCreate(CV_BDF, CV_NEWTON)
@@ -156,7 +156,7 @@ end
 return: (y,yp) two solution matrices representing the states and state derivatives
          with time steps in `t` along rows and state variable `y` or `yp` along columns
 """
-function idasol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
+function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                 reltol::Float64=1e-3, abstol::Float64=1e-6, diffstates::Union{Vector{Bool},Void}=nothing)
     mem = IDACreate()
     if mem == C_NULL

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -174,7 +174,7 @@ function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}
         flag = @checkflag IDADense(mem, length(y0))
         rtest = zeros(length(y0))
         f(t[1], y0, yp0, rtest)
-        if any(abs(rtest) .>= reltol)
+        if any(abs.(rtest) .>= reltol)
             if diffstates === nothing
                 error("Must supply diffstates argument to use IDA initial value solver.")
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,5 +64,5 @@ end
 println("== test common interface")
 let
 include(joinpath(examples_path, "common_interface.jl"))
-@test bool1 && bool2 && bool3 && bool4
+@test bool1 && bool2 && bool3 && bool4 && bool5 && bool6
 end


### PR DESCRIPTION
This PR implements the necessary algorithm and `solve` function to have IDA match the common interface for DAEs. The DAE solve function is similar to the ODE solve one, but there are some distinct differences in variable ordering in some of the IDA vs CVode functions which makes it too difficult to put them together (and there are some different checks that need to be done, etc.) so it's better to keep them separate. This will require the newest DiffEqBase tag.