### PR TITLE
Update common interface

### DIFF
--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -3,36 +3,39 @@ using DiffEqProblemLibrary, DiffEqBase, Sundials
 prob = prob_ode_linear
 dt = 1//2^(4)
 saveat = float(collect(0:dt:1))
-@time sol = solve(prob,CVODE_BDF)
-@time sol = solve(prob,CVODE_Adams)
-@time sol = solve(prob,CVODE_Adams,saveat=saveat)
+@time sol = solve(prob,CVODE_BDF())
+@time sol = solve(prob,CVODE_Adams())
+@time sol = solve(prob,CVODE_Adams(),saveat=saveat)
 bool1 = intersect(sol.t,saveat) == saveat
-@time sol = solve(prob,CVODE_Adams,saveat=saveat,save_timeseries=false)
+@time sol = solve(prob,CVODE_Adams(),saveat=saveat,save_timeseries=false)
 bool2 = sol.t == saveat
 
 prob = prob_ode_2Dlinear
-@time sol = solve(prob,CVODE_BDF)
-@time sol = solve(prob,CVODE_Adams)
-@time sol = solve(prob,CVODE_Adams,saveat=saveat)
+@time sol = solve(prob,CVODE_BDF())
+@time sol = solve(prob,CVODE_Adams())
+@time sol = solve(prob,CVODE_Adams(),saveat=saveat)
 bool3 = intersect(sol.t,saveat) == saveat
-@time sol = solve(prob,CVODE_Adams,saveat=saveat,save_timeseries=false)
+@time sol = solve(prob,CVODE_Adams(),saveat=saveat,save_timeseries=false)
 bool4 = sol.t == saveat
 
 # Test the other function conversions
 k = (t,u,du) -> du[1] = u[1]
 prob = ODEProblem(k,[1.0],(0.0,1.0))
-@time sol = solve(prob,CVODE_BDF)
+@time sol = solve(prob,CVODE_BDF())
 h = (t,u) -> u
 u0 = [1.0 2.0
       3.0 2.0]
 prob = ODEProblem(h,u0,(0.0,1.0))
-@time sol = solve(prob,CVODE_BDF)
+@time sol = solve(prob,CVODE_BDF())
+
+# Test Algorithm Choices
+@time sol = solve(prob,CVODE_BDF(method=:Functional))
 
 prob = prob_dae_resrob
 dt = 1000
 saveat = float(collect(0:dt:100000))
-sol = solve(prob,IDA)
-sol = solve(prob,IDA,saveat=saveat)
+sol = solve(prob,IDA())
+sol = solve(prob,IDA(),saveat=saveat)
 bool5 = intersect(sol.t,saveat) == saveat
-sol = solve(prob,IDA,saveat=saveat,save_timeseries=false)
+sol = solve(prob,IDA(),saveat=saveat,save_timeseries=false)
 bool6 = sol.t == saveat


### PR DESCRIPTION
Implements the changes from https://github.com/JuliaDiffEq/Sundials.jl/issues/97 .

Ex: `CVODE_BDF(method=:Functional)` now allows one to use the BDF method without a linear solver (and instead use functional iteration), solve @AlexanderKoshkarov 's memory problem. 

This could get expanded in the future since it still only has the dense solver, and support for the banded solver should be added in a future PR.