### PR TITLE
Expose Linear Solvers in Common Interface

### DIFF
--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -36,9 +36,11 @@ prob = ODEProblem(h,u0,(0.0,1.0))
 
 # Test Algorithm Choices
 @time sol1 = solve(prob,CVODE_BDF(method=:Functional))
-@time sol2 = solve(prob,CVODE_BDF(linear_solver=:Band,jac_upper=3,jac_lower=3))
+@time sol2 = solve(prob,CVODE_BDF(linear_solver=:Banded,jac_upper=3,jac_lower=3))
+@time sol3 = solve(prob,CVODE_BDF(linear_solver=:Diagonal))
 
 @test isapprox(sol1[end],sol2[end],rtol=1e-3)
+@test isapprox(sol1[end],sol3[end],rtol=1e-3)
 
 # Test DAE
 prob = prob_dae_resrob

--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -38,9 +38,15 @@ prob = ODEProblem(h,u0,(0.0,1.0))
 @time sol1 = solve(prob,CVODE_BDF(method=:Functional))
 @time sol2 = solve(prob,CVODE_BDF(linear_solver=:Banded,jac_upper=3,jac_lower=3))
 @time sol3 = solve(prob,CVODE_BDF(linear_solver=:Diagonal))
+@time sol4 = solve(prob,CVODE_BDF(linear_solver=:GMRES))
+@time sol5 = solve(prob,CVODE_BDF(linear_solver=:BCG))
+@time sol6 = solve(prob,CVODE_BDF(linear_solver=:TFQMR))
 
 @test isapprox(sol1[end],sol2[end],rtol=1e-3)
 @test isapprox(sol1[end],sol3[end],rtol=1e-3)
+@test isapprox(sol1[end],sol4[end],rtol=1e-3)
+@test isapprox(sol1[end],sol5[end],rtol=1e-3)
+@test isapprox(sol1[end],sol6[end],rtol=1e-3)
 
 # Test DAE
 prob = prob_dae_resrob

--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -6,17 +6,23 @@ saveat = float(collect(0:dt:1))
 @time sol = solve(prob,CVODE_BDF())
 @time sol = solve(prob,CVODE_Adams())
 @time sol = solve(prob,CVODE_Adams(),saveat=saveat)
-bool1 = intersect(sol.t,saveat) == saveat
+
+@test intersect(sol.t,saveat) == saveat
+
 @time sol = solve(prob,CVODE_Adams(),saveat=saveat,save_timeseries=false)
-bool2 = sol.t == saveat
+
+@test sol.t == saveat
 
 prob = prob_ode_2Dlinear
 @time sol = solve(prob,CVODE_BDF())
 @time sol = solve(prob,CVODE_Adams())
 @time sol = solve(prob,CVODE_Adams(),saveat=saveat)
-bool3 = intersect(sol.t,saveat) == saveat
+
+@test intersect(sol.t,saveat) == saveat
+
 @time sol = solve(prob,CVODE_Adams(),saveat=saveat,save_timeseries=false)
-bool4 = sol.t == saveat
+
+@test sol.t == saveat
 
 # Test the other function conversions
 k = (t,u,du) -> du[1] = u[1]
@@ -29,13 +35,20 @@ prob = ODEProblem(h,u0,(0.0,1.0))
 @time sol = solve(prob,CVODE_BDF())
 
 # Test Algorithm Choices
-@time sol = solve(prob,CVODE_BDF(method=:Functional))
+@time sol1 = solve(prob,CVODE_BDF(method=:Functional))
+@time sol2 = solve(prob,CVODE_BDF(linear_solver=:Band,jac_upper=3,jac_lower=3))
 
+@test isapprox(sol1[end],sol2[end],rtol=1e-3)
+
+# Test DAE
 prob = prob_dae_resrob
 dt = 1000
 saveat = float(collect(0:dt:100000))
 sol = solve(prob,IDA())
 sol = solve(prob,IDA(),saveat=saveat)
-bool5 = intersect(sol.t,saveat) == saveat
+
+@test intersect(sol.t,saveat) == saveat
+
 sol = solve(prob,IDA(),saveat=saveat,save_timeseries=false)
-bool6 = sol.t == saveat
+
+@test sol.t == saveat

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -42,6 +42,7 @@ end
 include("kinsol.jl")
 
 include("simple.jl")
+include("algorithms.jl")
 include("common.jl")
 
 ##################################################################

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -11,7 +11,7 @@ immutable CVODE_BDF{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSo
 end
 function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
                     jac_upper=0,jac_lower=0)
-    if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
+    if linear_solver == :Banded && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
     end
     CVODE_BDF{method,linear_solver}(jac_upper,jac_lower)
@@ -23,7 +23,7 @@ immutable CVODE_Adams{Method,LinearSolver} <: SundialsODEAlgorithm{Method,Linear
 end
 function CVODE_Adams(;method=:Functional,linear_solver=:None,
                       jac_upper=0,jac_lower=0)
-    if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
+    if linear_solver == :Banded && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
     end
     CVODE_Adams{method,linear_solver}(jac_upper,jac_lower)
@@ -35,7 +35,7 @@ immutable IDA{LinearSolver} <: SundialsDAEAlgorithm{LinearSolver}
   jac_lower::Int
 end
 function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0)
-  if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
+  if linear_solver == :Banded && (jac_upper==0 || jac_lower==0)
       error("Banded solver must set the jac_upper and jac_lower")
   end
   IDA{linear_solver}(jac_upper,jac_lower)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,0 +1,42 @@
+# Sundials.jl algorithms
+
+# Abstract Types
+abstract SundialsODEAlgorithm{Method,LinearSolver} <: AbstractODEAlgorithm
+abstract SundialsDAEAlgorithm{LinearSolver} <: AbstractDAEAlgorithm
+
+# ODE Algorithms
+immutable CVODE_BDF{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver}
+  jac_upper::Int
+  jac_lower::Int
+end
+function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
+                    jac_upper=0,jac_lower=0)
+    if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
+        error("Banded solver must set the jac_upper and jac_lower")
+    end
+    CVODE_BDF{method,linear_solver}(jac_upper,jac_lower)
+end
+
+immutable CVODE_Adams{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver}
+  jac_upper::Int
+  jac_lower::Int
+end
+function CVODE_Adams(;method=:Functional,linear_solver=:None,
+                      jac_upper=0,jac_lower=0)
+    if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
+        error("Banded solver must set the jac_upper and jac_lower")
+    end
+    CVODE_Adams{method,linear_solver}(jac_upper,jac_lower)
+end
+
+# DAE Algorithms
+immutable IDA{LinearSolver} <: SundialsDAEAlgorithm{LinearSolver}
+  jac_upper::Int
+  jac_lower::Int
+end
+function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0)
+  if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
+      error("Banded solver must set the jac_upper and jac_lower")
+  end
+  IDA{linear_solver}(jac_upper,jac_lower)
+end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -8,35 +8,38 @@ abstract SundialsDAEAlgorithm{LinearSolver} <: AbstractDAEAlgorithm
 immutable CVODE_BDF{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver}
   jac_upper::Int
   jac_lower::Int
+  krylov_dim::Int
 end
 function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
-                    jac_upper=0,jac_lower=0)
+                    jac_upper=0,jac_lower=0,non_zero=0,krylov_dim=0)
     if linear_solver == :Banded && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
     end
-    CVODE_BDF{method,linear_solver}(jac_upper,jac_lower)
+    CVODE_BDF{method,linear_solver}(jac_upper,jac_lower,krylov_dim)
 end
 
 immutable CVODE_Adams{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver}
   jac_upper::Int
   jac_lower::Int
+  krylov_dim::Int
 end
 function CVODE_Adams(;method=:Functional,linear_solver=:None,
-                      jac_upper=0,jac_lower=0)
+                      jac_upper=0,jac_lower=0,krylov_dim=0)
     if linear_solver == :Banded && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
     end
-    CVODE_Adams{method,linear_solver}(jac_upper,jac_lower)
+    CVODE_Adams{method,linear_solver}(jac_upper,jac_lower,krylov_dim)
 end
 
 # DAE Algorithms
 immutable IDA{LinearSolver} <: SundialsDAEAlgorithm{LinearSolver}
   jac_upper::Int
   jac_lower::Int
+  krylov_dim::Int
 end
-function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0)
+function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,krylov_dim=0)
   if linear_solver == :Banded && (jac_upper==0 || jac_lower==0)
       error("Banded solver must set the jac_upper and jac_lower")
   end
-  IDA{linear_solver}(jac_upper,jac_lower)
+  IDA{linear_solver}(jac_upper,jac_lower,krylov_dim)
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -219,15 +219,15 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
         if LinearSolver == :Dense
             flag = @checkflag IDADense(mem, length(u0))
         elseif LinearSolver == :Band
-            flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+            flag = @checkflag IDABand(mem,length(u0),alg.jac_upper,alg.jac_lower)
         elseif LinearSolver == :Diagonal
-            flag = @checkflag CVDiag(mem)
+            flag = @checkflag IDADiag(mem)
         elseif LinearSolver == :GMRES
-            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+            flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
         elseif LinearSolver == :BCG
-            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+            flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
         elseif LinearSolver == :TFQMR
-            flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
+            flag = @checkflag IDASptfqmr(mem,PREC_NONE,alg.krylov_dim)
         end
 
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -223,11 +223,11 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
         elseif LinearSolver == :Diagonal
             flag = @checkflag CVDiag(mem)
         elseif LinearSolver == :GMRES
-            flag = @checkflag CVpgmr(mem,PREC_NONE,alg.krylov_dim)
+            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
         elseif LinearSolver == :BCG
-            flag = @checkflag CVpgmr(mem,PREC_NONE,alg.krylov_dim)
+            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
         elseif LinearSolver == :TFQMR
-            flag = @checkflag CVptfqmr(mem,PREC_NONE,alg.krylov_dim)
+            flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
         end
 
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -81,6 +81,12 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                 flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
             elseif LinearSolver == :Diagonal
                 flag = @checkflag CVDiag(mem)
+            elseif LinearSolver == :GMRES
+                flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+            elseif LinearSolver == :BCG
+                flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+            elseif LinearSolver == :TFQMR
+                flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
             end
         end
 
@@ -216,7 +222,14 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
             flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
         elseif LinearSolver == :Diagonal
             flag = @checkflag CVDiag(mem)
+        elseif LinearSolver == :GMRES
+            flag = @checkflag CVpgmr(mem,PREC_NONE,alg.krylov_dim)
+        elseif LinearSolver == :BCG
+            flag = @checkflag CVpgmr(mem,PREC_NONE,alg.krylov_dim)
+        elseif LinearSolver == :TFQMR
+            flag = @checkflag CVptfqmr(mem,PREC_NONE,alg.krylov_dim)
         end
+
 
         push!(ures, copy(u0))
         utmp = NVector(copy(u0))

--- a/src/common.jl
+++ b/src/common.jl
@@ -77,8 +77,10 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
         if Method == :Newton # Only use a linear solver if it's a Newton-based method
             if LinearSolver == :Dense
                 flag = @checkflag CVDense(mem, length(u0))
-            elseif LinearSolver == :Band
+            elseif LinearSolver == :Banded
                 flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+            elseif LinearSolver == :Diagonal
+                flag = @checkflag CVDiag(mem)
             end
         end
 
@@ -212,6 +214,8 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
             flag = @checkflag IDADense(mem, length(u0))
         elseif LinearSolver == :Band
             flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+        elseif LinearSolver == :Diagonal
+            flag = @checkflag CVDiag(mem)
         end
 
         push!(ures, copy(u0))

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,19 +1,4 @@
-# Sundials.jl algorithms
-
-# Abstract Types
-abstract SundialsODEAlgorithm{Method,LinearSolver} <: AbstractODEAlgorithm
-abstract SundialsDAEAlgorithm{LinearSolver} <: AbstractDAEAlgorithm
-
-# ODE Algorithms
-immutable CVODE_BDF{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver} end
-CVODE_BDF(;method=:Newton,linear_solver=:Dense) = CVODE_BDF{method,linear_solver}()
-
-immutable CVODE_Adams{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver} end
-CVODE_Adams(;method=:Functional,linear_solver=:None) = CVODE_Adams{method,linear_solver}()
-
-# DAE Algorithms
-immutable IDA{LinearSolver} <: SundialsDAEAlgorithm{LinearSolver} end
-IDA(;linear_solver=:Dense) = IDA{linear_solver}()
+## Common Interface Solve Functions
 
 function solve{uType,tType,isinplace,F,Method,LinearSolver}(
     prob::AbstractODEProblem{uType,tType,isinplace,F},
@@ -92,6 +77,8 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
         if Method == :Newton # Only use a linear solver if it's a Newton-based method
             if LinearSolver == :Dense
                 flag = @checkflag CVDense(mem, length(u0))
+            elseif LinearSolver == :Band
+                flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
             end
         end
 
@@ -223,6 +210,8 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
         flag = @checkflag IDASetMaxNumSteps(mem, maxiter)
         if LinearSolver == :Dense
             flag = @checkflag IDADense(mem, length(u0))
+        elseif LinearSolver == :Band
+            flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
         end
 
         push!(ures, copy(u0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,5 @@ end
 
 println("== test common interface")
 let
-include(joinpath(examples_path, "common_interface.jl"))
-@test bool1 && bool2 && bool3 && bool4 && bool5 && bool6
+@testset "Common Interface" begin include(joinpath(examples_path, "common_interface.jl")) end
 end


### PR DESCRIPTION
This update exposes the banded linear solver in the common interface, allowing a user to solve a problem using something like:

```julia
sol = solve(prob,CVODE_BDF(linear_solver=:Band,jac_upper=3,jac_lower=3))
```

which will be much more efficient than the dense solver. The common interface tests were also moved to a testset since they have grown.