### PR TITLE
Add finalizers to mem types

### DIFF
--- a/examples/cvode_Roberts_dns.jl
+++ b/examples/cvode_Roberts_dns.jl
@@ -50,7 +50,7 @@ const y0 = [1.0, 0.0, 0.0]
 const reltol = 1e-4
 const abstol = [1e-8, 1e-14, 1e-6]
 
-cvode_mem = Sundials.CVodeCreate(Sundials.CV_BDF, Sundials.CV_NEWTON)
+cvode_mem = Sundials.CVODEMemContainer(Sundials.CV_BDF, Sundials.CV_NEWTON)
 Sundials.@checkflag Sundials.CVodeInit(cvode_mem, f, t0, y0)
 Sundials.@checkflag Sundials.CVodeSVtolerances(cvode_mem, reltol, abstol)
 Sundials.@checkflag Sundials.CVodeRootInit(cvode_mem, 2, g)

--- a/examples/ida_Cable.jl
+++ b/examples/ida_Cable.jl
@@ -91,7 +91,7 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
                     reltol::Float64=1e-4, abstol::Float64=1e-6)
 
     neq = length(y0)
-    mem = Sundials.IDACreate()
+    mem = Sundials.IDAMemContainer()
     Sundials.@checkflag Sundials.IDAInit(mem, cfunction(Sundials.idasolfun, Cint,
                                          (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{Function})),
                                          t[1], y0, yp0)

--- a/examples/ida_Heat2D.jl
+++ b/examples/ida_Heat2D.jl
@@ -107,7 +107,7 @@ function idabandsol(f::Function, y0::Vector{Float64}, yp0::Vector{Float64},
                     t::Vector{Float64};
                     reltol::Float64=1e-4, abstol::Float64=1e-6)
     neq = length(y0)
-    mem = Sundials.IDACreate()
+    mem = Sundials.IDAMemContainer()
     Sundials.@checkflag Sundials.IDAInit(mem, cfunction(Sundials.idasolfun, Cint,
                                          (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{Function})),
                                          t[1], y0, yp0)

--- a/examples/ida_Roberts_dns.jl
+++ b/examples/ida_Roberts_dns.jl
@@ -80,7 +80,7 @@ const rtol = 1e-4
 const avtol = [1e-8, 1e-14, 1e-6]
 const tout1 = 0.4
 
-mem = Sundials.IDACreate()
+mem = Sundials.IDAMemContainer()
 Sundials.@checkflag Sundials.IDAInit(mem, resrob, t0, yy0, yp0)
 Sundials.@checkflag Sundials.IDASVtolerances(mem, rtol, avtol)
 

--- a/examples/kinsol_mkinTest.jl
+++ b/examples/kinsol_mkinTest.jl
@@ -22,7 +22,7 @@ end
 
 ## Initialize problem
 const neq = 2
-kmem = Sundials.KINCreate()
+kmem = Sundials.KINMemContainer()
 Sundials.@checkflag Sundials.KINSetFuncNormTol(kmem, 1.0e-5)
 Sundials.@checkflag Sundials.KINSetScaledStepTol(kmem, 1.0e-4)
 Sundials.@checkflag Sundials.KINSetMaxSetupCalls(kmem, 1)

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -4,6 +4,7 @@ module Sundials
 
 using Compat, DiffEqBase
 import DiffEqBase: solve
+import Base: convert
 
 const depsfile = joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl")
 if isfile(depsfile)
@@ -44,6 +45,11 @@ include("kinsol.jl")
 include("simple.jl")
 include("algorithms.jl")
 include("common.jl")
+
+### Finalizers
+
+# Note that these have to go after the respective library (cvode.jl, etc.)
+# And those have to go after the type definition for the dispatches
 
 ##################################################################
 # Deprecations

--- a/src/common.jl
+++ b/src/common.jl
@@ -54,79 +54,75 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
         method_code = CV_FUNCTIONAL
     end
 
-    mem = CVodeCreate(alg_code, method_code)
+    mem = CVODEMemContainer(alg_code, method_code)
 
-    if mem == C_NULL
+    if mem.ptr == C_NULL
         error("Failed to allocate CVODE solver object")
     end
 
     ures = Vector{Vector{Float64}}()
     ts   = [t0]
 
-    try
-        userfun = UserFunctionAndData(f!, userdata)
-        u0nv = NVector(u0)
-        flag = @checkflag CVodeInit(mem,
-                              cfunction(cvodefun, Cint,
-                              (realtype, N_Vector,
-                              N_Vector, Ref{typeof(userfun)})),
-                              t0, convert(N_Vector, u0nv))
-        flag = @checkflag CVodeSetUserData(mem, userfun)
-        flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
-        flag = @checkflag CVodeSetMaxNumSteps(mem, maxiter)
-        if Method == :Newton # Only use a linear solver if it's a Newton-based method
-            if LinearSolver == :Dense
-                flag = @checkflag CVDense(mem, length(u0))
-            elseif LinearSolver == :Banded
-                flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
-            elseif LinearSolver == :Diagonal
-                flag = @checkflag CVDiag(mem)
-            elseif LinearSolver == :GMRES
-                flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
-            elseif LinearSolver == :BCG
-                flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
-            elseif LinearSolver == :TFQMR
-                flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
-            end
+    userfun = UserFunctionAndData(f!, userdata)
+    u0nv = NVector(u0)
+    flag = @checkflag CVodeInit(mem,
+                          cfunction(cvodefun, Cint,
+                          (realtype, N_Vector,
+                          N_Vector, Ref{typeof(userfun)})),
+                          t0, convert(N_Vector, u0nv))
+    flag = @checkflag CVodeSetUserData(mem, userfun)
+    flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
+    flag = @checkflag CVodeSetMaxNumSteps(mem, maxiter)
+    if Method == :Newton # Only use a linear solver if it's a Newton-based method
+        if LinearSolver == :Dense
+            flag = @checkflag CVDense(mem, length(u0))
+        elseif LinearSolver == :Banded
+            flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+        elseif LinearSolver == :Diagonal
+            flag = @checkflag CVDiag(mem)
+        elseif LinearSolver == :GMRES
+            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+        elseif LinearSolver == :BCG
+            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+        elseif LinearSolver == :TFQMR
+            flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
         end
+    end
 
-        push!(ures, copy(u0))
-        utmp = NVector(copy(u0))
-        tout = [0.0]
+    push!(ures, copy(u0))
+    utmp = NVector(copy(u0))
+    tout = [0.0]
 
-        # The Inner Loops : Style depends on save_timeseries
-        if save_timeseries
-            for k in 2:length(save_ts)
-                looped = false
-                while tout[end] < save_ts[k]
-                    looped = true
-                    flag = @checkflag CVode(mem,
-                                    save_ts[k], utmp, tout, CV_ONE_STEP)
-                    push!(ures,copy(utmp))
-                    push!(ts, tout...)
-                end
-                if looped
-                    # Fix the end
-                    flag = @checkflag CVodeGetDky(
-                                            mem, save_ts[k], Cint(0), ures[end])
-                    ts[end] = save_ts[k]
-                else # Just push another value
-                    flag = @checkflag CVodeGetDky(
-                                            mem, save_ts[k], Cint(0), utmp)
-                    push!(ures,copy(utmp))
-                    push!(ts, save_ts[k]...)
-                end
-            end
-        else # save_timeseries == false, so use CV_NORMAL style
-            for k in 2:length(save_ts)
+    # The Inner Loops : Style depends on save_timeseries
+    if save_timeseries
+        for k in 2:length(save_ts)
+            looped = false
+            while tout[end] < save_ts[k]
+                looped = true
                 flag = @checkflag CVode(mem,
-                                    save_ts[k], utmp, tout, CV_NORMAL)
+                                save_ts[k], utmp, tout, CV_ONE_STEP)
                 push!(ures,copy(utmp))
+                push!(ts, tout...)
             end
-            ts = save_ts
+            if looped
+                # Fix the end
+                flag = @checkflag CVodeGetDky(
+                                        mem, save_ts[k], Cint(0), ures[end])
+                ts[end] = save_ts[k]
+            else # Just push another value
+                flag = @checkflag CVodeGetDky(
+                                        mem, save_ts[k], Cint(0), utmp)
+                push!(ures,copy(utmp))
+                push!(ts, save_ts[k]...)
+            end
         end
-    finally
-        CVodeFree(Ref{CVODEMemPtr}(mem))
+    else # save_timeseries == false, so use CV_NORMAL style
+        for k in 2:length(save_ts)
+            flag = @checkflag CVode(mem,
+                                save_ts[k], utmp, tout, CV_NORMAL)
+            push!(ures,copy(utmp))
+        end
+        ts = save_ts
     end
 
     ### Finishing Routine
@@ -197,89 +193,85 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
                           u = vec(u); du=vec(du); 0)
     end
 
-    mem = IDACreate()
-    if mem == C_NULL
+    mem = IDAMemContainer()
+    if mem.ptr == C_NULL
         error("Failed to allocate IDA solver object")
     end
 
     ures = Vector{Vector{Float64}}()
     ts   = [t0]
 
-    try
-        userfun = UserFunctionAndData(f!, userdata)
-        u0nv = NVector(u0)
-        flag = @checkflag IDAInit(mem, cfunction(idasolfun,
-                                  Cint, (realtype, N_Vector, N_Vector,
-                                  N_Vector, Ref{typeof(userfun)})),
-                                  t0, convert(N_Vector, u0),
-                                  convert(N_Vector, du0))
-        flag = @checkflag IDASetUserData(mem, userfun)
-        flag = @checkflag IDASStolerances(mem, reltol, abstol)
-        flag = @checkflag IDASetMaxNumSteps(mem, maxiter)
-        if LinearSolver == :Dense
-            flag = @checkflag IDADense(mem, length(u0))
-        elseif LinearSolver == :Band
-            flag = @checkflag IDABand(mem,length(u0),alg.jac_upper,alg.jac_lower)
-        elseif LinearSolver == :Diagonal
-            flag = @checkflag IDADiag(mem)
-        elseif LinearSolver == :GMRES
-            flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
-        elseif LinearSolver == :BCG
-            flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
-        elseif LinearSolver == :TFQMR
-            flag = @checkflag IDASptfqmr(mem,PREC_NONE,alg.krylov_dim)
+    userfun = UserFunctionAndData(f!, userdata)
+    u0nv = NVector(u0)
+    flag = @checkflag IDAInit(mem, cfunction(idasolfun,
+                              Cint, (realtype, N_Vector, N_Vector,
+                              N_Vector, Ref{typeof(userfun)})),
+                              t0, convert(N_Vector, u0),
+                              convert(N_Vector, du0))
+    flag = @checkflag IDASetUserData(mem, userfun)
+    flag = @checkflag IDASStolerances(mem, reltol, abstol)
+    flag = @checkflag IDASetMaxNumSteps(mem, maxiter)
+    if LinearSolver == :Dense
+        flag = @checkflag IDADense(mem, length(u0))
+    elseif LinearSolver == :Band
+        flag = @checkflag IDABand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+    elseif LinearSolver == :Diagonal
+        flag = @checkflag IDADiag(mem)
+    elseif LinearSolver == :GMRES
+        flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
+    elseif LinearSolver == :BCG
+        flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
+    elseif LinearSolver == :TFQMR
+        flag = @checkflag IDASptfqmr(mem,PREC_NONE,alg.krylov_dim)
+    end
+
+
+    push!(ures, copy(u0))
+    utmp = NVector(copy(u0))
+    dutmp = NVector(copy(u0))
+    tout = [0.0]
+
+    rtest = zeros(length(u0))
+    f!(t0, u0, du0, rtest)
+    if any(abs.(rtest) .>= reltol)
+        if diffstates === nothing
+            error("Must supply diffstates argument to use IDA initial value solver.")
         end
+        flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
+        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[2])
+    end
 
-
-        push!(ures, copy(u0))
-        utmp = NVector(copy(u0))
-        dutmp = NVector(copy(u0))
-        tout = [0.0]
-
-        rtest = zeros(length(u0))
-        f!(t0, u0, du0, rtest)
-        if any(abs.(rtest) .>= reltol)
-            if diffstates === nothing
-                error("Must supply diffstates argument to use IDA initial value solver.")
-            end
-            flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
-            flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[2])
-        end
-
-        # The Inner Loops : Style depends on save_timeseries
-        if save_timeseries
-            for k in 2:length(save_ts)
-                looped = false
-                while tout[end] < save_ts[k]
-                    looped = true
-                    flag = @checkflag IDASolve(mem,
-                                    save_ts[k], tout, utmp, dutmp, IDA_ONE_STEP)
-
-                    push!(ures,copy(utmp))
-                    push!(ts, tout...)
-                end
-                if looped
-                    # Fix the end
-                    flag = @checkflag IDAGetDky(
-                                            mem, save_ts[k], Cint(0), ures[end])
-                    ts[end] = save_ts[k]
-                else # Just push another value
-                    flag = @checkflag IDAGetDky(
-                                            mem, save_ts[k], Cint(0), utmp)
-                    push!(ures,copy(utmp))
-                    push!(ts, save_ts[k]...)
-                end
-            end
-        else # save_timeseries == false, so use IDA_NORMAL style
-            for k in 2:length(save_ts)
+    # The Inner Loops : Style depends on save_timeseries
+    if save_timeseries
+        for k in 2:length(save_ts)
+            looped = false
+            while tout[end] < save_ts[k]
+                looped = true
                 flag = @checkflag IDASolve(mem,
-                                    save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
+                                save_ts[k], tout, utmp, dutmp, IDA_ONE_STEP)
+
                 push!(ures,copy(utmp))
+                push!(ts, tout...)
             end
-            ts = save_ts
+            if looped
+                # Fix the end
+                flag = @checkflag IDAGetDky(
+                                        mem, save_ts[k], Cint(0), ures[end])
+                ts[end] = save_ts[k]
+            else # Just push another value
+                flag = @checkflag IDAGetDky(
+                                        mem, save_ts[k], Cint(0), utmp)
+                push!(ures,copy(utmp))
+                push!(ts, save_ts[k]...)
+            end
         end
-    finally
-        IDAFree(Ref{IDAMemPtr}(mem))
+    else # save_timeseries == false, so use IDA_NORMAL style
+        for k in 2:length(save_ts)
+            flag = @checkflag IDASolve(mem,
+                                save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
+            push!(ures,copy(utmp))
+        end
+        ts = save_ts
     end
 
     ### Finishing Routine

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -14,13 +14,43 @@
 abstract AbstractSundialsObject
 
 immutable CVODEMem <: AbstractSundialsObject end
+type CVODEMemContainer <: AbstractSundialsObject
+    ptr::Ptr{CVODEMem}
+    function CVODEMemContainer(lmm, iter)
+        ptr = new(CVodeCreate(lmm,iter))
+        finalizer(ptr,cvode_finalizer)
+        ptr
+    end
+end
 typealias CVODEMemPtr Ptr{CVODEMem}
+cvode_finalizer(mem::CVODEMemContainer) = mem.ptr == C_NULL || (CVodeFree(Ref{CVODEMemPtr}(mem.ptr)) ; mem.ptr = C_NULL)
+convert(::Type{CVODEMemPtr},mem::CVODEMemContainer) = mem.ptr
 
 immutable IDAMem <: AbstractSundialsObject end
+type IDAMemContainer <: AbstractSundialsObject
+  ptr::Ptr{IDAMem}
+  function IDAMemContainer()
+      ptr = new(IDACreate())
+      finalizer(ptr,ida_finalizer)
+      ptr
+  end
+end
 typealias IDAMemPtr Ptr{IDAMem}
+ida_finalizer(mem::IDAMemContainer) = mem.ptr == C_NULL || (IDAFree(Ref{IDAMemPtr}(mem.ptr)) ; mem.ptr = C_NULL)
+convert(::Type{IDAMemPtr},mem::IDAMemContainer) = mem.ptr
 
 immutable KINMem <: AbstractSundialsObject end
+type KINMemContainer <: AbstractSundialsObject
+  ptr::Ptr{KINMem}
+  function KINMemContainer()
+      ptr = new(KINCreate())
+      finalizer(ptr,kin_finalizer)
+      ptr
+  end
+end
 typealias KINMemPtr Ptr{KINMem}
+kin_finalizer(mem::KINMemContainer) = mem.ptr == C_NULL || (KINFree(Ref{KINMemPtr}(mem.ptr)) ; mem.ptr = C_NULL)
+convert(::Type{KINMemPtr},mem::KINMemContainer) = mem.ptr
 
 """
    Handle for Sundials objects (CVODE, IDA, KIN).

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -45,26 +45,23 @@ function kinsol(f::Function, y0::Vector{Float64}, userdata::Any = nothing)
     #    where `y` is the input vector, and `fy` is the result of the function
     # y0, Vector of initial values
     # return: the solution vector
-    kmem = KINCreate()
-    if kmem == C_NULL
+    kmem = KINMemContainer()
+    if kmem.ptr == C_NULL
         error("Failed to allocate KINSOL solver object")
     end
 
     y = copy(y0)
-    try
-        # use the user_data field to pass a function
-        #   see: https://github.com/JuliaLang/julia/issues/2554
-        userfun = UserFunctionAndData(f, userdata)
-        flag = @checkflag KINInit(kmem, cfunction(kinsolfun, Cint, (N_Vector, N_Vector, Ref{typeof(userfun)})), NVector(y0))
-        flag = @checkflag KINDense(kmem, length(y0))
-        flag = @checkflag KINSetUserData(kmem, userfun)
-        ## Solve problem
-        scale = ones(length(y0))
-        strategy = KIN_NONE
-        flag = @checkflag KINSol(kmem, y, strategy, scale, scale)
-    finally
-        KINFree(Ref{KINMemPtr}(kmem))
-    end
+
+    # use the user_data field to pass a function
+    #   see: https://github.com/JuliaLang/julia/issues/2554
+    userfun = UserFunctionAndData(f, userdata)
+    flag = @checkflag KINInit(kmem, cfunction(kinsolfun, Cint, (N_Vector, N_Vector, Ref{typeof(userfun)})), NVector(y0))
+    flag = @checkflag KINDense(kmem, length(y0))
+    flag = @checkflag KINSetUserData(kmem, userfun)
+    ## Solve problem
+    scale = ones(length(y0))
+    strategy = KIN_NONE
+    flag = @checkflag KINSol(kmem, y, strategy, scale, scale)
 
     return y
 end
@@ -100,32 +97,30 @@ return: a solution matrix with time steps in `t` along rows and
 function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
               integrator=:BDF, reltol::Float64=1e-3, abstol::Float64=1e-6)
     if integrator==:BDF
-        mem = CVodeCreate(CV_BDF, CV_NEWTON)
+        mem = CVODEMemContainer(CV_BDF, CV_NEWTON)
     elseif integrator==:Adams
-        mem = CVodeCreate(CV_ADAMS, CV_FUNCTIONAL)
+        mem = CVODEMemContainer(CV_ADAMS, CV_FUNCTIONAL)
     end
-    if mem == C_NULL
+    if mem.ptr == C_NULL
         error("Failed to allocate CVODE solver object")
     end
 
     yres = zeros(length(t), length(y0))
-    try
-        userfun = UserFunctionAndData(f, userdata)
-        y0nv = NVector(y0)
-        flag = @checkflag CVodeInit(mem, cfunction(cvodefun, Cint, (realtype, N_Vector, N_Vector, Ref{typeof(userfun)})), t[1], convert(N_Vector, y0nv))
-        flag = @checkflag CVodeSetUserData(mem, userfun)
-        flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
-        flag = @checkflag CVDense(mem, length(y0))
-        yres[1,:] = y0
-        ynv = NVector(copy(y0))
-        tout = [0.0]
-        for k in 2:length(t)
-            flag = @checkflag CVode(mem, t[k], ynv, tout, CV_NORMAL)
-            yres[k,:] = convert(Vector, ynv)
-        end
-    finally
-        CVodeFree(Ref{CVODEMemPtr}(mem))
+
+    userfun = UserFunctionAndData(f, userdata)
+    y0nv = NVector(y0)
+    flag = @checkflag CVodeInit(mem, cfunction(cvodefun, Cint, (realtype, N_Vector, N_Vector, Ref{typeof(userfun)})), t[1], convert(N_Vector, y0nv))
+    flag = @checkflag CVodeSetUserData(mem, userfun)
+    flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
+    flag = @checkflag CVDense(mem, length(y0))
+    yres[1,:] = y0
+    ynv = NVector(copy(y0))
+    tout = [0.0]
+    for k in 2:length(t)
+        flag = @checkflag CVode(mem, t[k], ynv, tout, CV_NORMAL)
+        yres[k,:] = convert(Vector, ynv)
     end
+
     return yres
 end
 
@@ -158,41 +153,38 @@ return: (y,yp) two solution matrices representing the states and state derivativ
 """
 function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                 reltol::Float64=1e-3, abstol::Float64=1e-6, diffstates::Union{Vector{Bool},Void}=nothing)
-    mem = IDACreate()
-    if mem == C_NULL
+    mem = IDAMemContainer()
+    if mem.ptr == C_NULL
         error("Failed to allocate IDA solver object")
     end
 
     yres = zeros(length(t), length(y0))
     ypres = zeros(length(t), length(y0))
-    try
-        userfun = UserFunctionAndData(f, userdata)
-        flag = @checkflag IDAInit(mem, cfunction(idasolfun, Cint, (realtype, N_Vector, N_Vector, N_Vector, Ref{typeof(userfun)})),
-                                  t[1], y0, yp0)
-        flag = @checkflag IDASetUserData(mem, userfun)
-        flag = @checkflag IDASStolerances(mem, reltol, abstol)
-        flag = @checkflag IDADense(mem, length(y0))
-        rtest = zeros(length(y0))
-        f(t[1], y0, yp0, rtest)
-        if any(abs.(rtest) .>= reltol)
-            if diffstates === nothing
-                error("Must supply diffstates argument to use IDA initial value solver.")
-            end
-            flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
-            flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, t[2])
+
+    userfun = UserFunctionAndData(f, userdata)
+    flag = @checkflag IDAInit(mem, cfunction(idasolfun, Cint, (realtype, N_Vector, N_Vector, N_Vector, Ref{typeof(userfun)})),
+                              t[1], y0, yp0)
+    flag = @checkflag IDASetUserData(mem, userfun)
+    flag = @checkflag IDASStolerances(mem, reltol, abstol)
+    flag = @checkflag IDADense(mem, length(y0))
+    rtest = zeros(length(y0))
+    f(t[1], y0, yp0, rtest)
+    if any(abs.(rtest) .>= reltol)
+        if diffstates === nothing
+            error("Must supply diffstates argument to use IDA initial value solver.")
         end
-        yres[1,:] = y0
-        ypres[1,:] = yp0
-        y = copy(y0)
-        yp = copy(yp0)
-        tout = [0.0]
-        for k in 2:length(t)
-            retval = @checkflag IDASolve(mem, t[k], tout, y, yp, IDA_NORMAL)
-            yres[k,:] = y
-            ypres[k,:] = yp
-        end
-    finally
-        IDAFree(Ref{IDAMemPtr}(mem))
+        flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
+        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, t[2])
+    end
+    yres[1,:] = y0
+    ypres[1,:] = yp0
+    y = copy(y0)
+    yp = copy(yp0)
+    tout = [0.0]
+    for k in 2:length(t)
+        retval = @checkflag IDASolve(mem, t[k], tout, y, yp, IDA_NORMAL)
+        yres[k,:] = y
+        ypres[k,:] = yp
     end
 
     return yres, ypres


### PR DESCRIPTION
Closes #96 and opens up the possibility of #100 by changing to using mem pointer containers such as `CVODEMemContainer` with a finalizer on the type so that way garbage collection handles freeing (instead of the fragile try/finally requirement!). 

Conversions such as 

```julia
convert(::Type{CVODEMemPtr},mem::CVODEMemContainer) = mem.ptr
```

are used so that way the Clang auto-generated code is pretty much untouched, allowing for future changes like #89 to not be difficult. This does cause an internal API change, for example `CVODEMemContainer(CV_BDF, CV_NEWTON)` instead of `CVodeCreate(CV_BDF, CV_NEWTON)`. The simple and common interfaces were fixed to reflect this (but have no user-facing change), and so were the examples.

@musm @mauro3