### PR TITLE
move high level APIs to Handle

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -59,7 +59,7 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
         method_code = CV_FUNCTIONAL
     end
 
-    mem = CVodeCreate(alg_code, method_code)
+    mem = Handle(CVodeCreate(alg_code, method_code))
 
     if mem == C_NULL
         error("Failed to allocate CVODE solver object")
@@ -68,70 +68,66 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
     ures = Vector{Vector{Float64}}()
     ts   = [t0]
 
-    try
-        userfun = UserFunctionAndData(f!, userdata)
-        u0nv = NVector(u0)
-        flag = @checkflag CVodeInit(mem,
-                              cfunction(cvodefun, Cint,
-                              (realtype, N_Vector,
-                              N_Vector, Ref{typeof(userfun)})),
-                              t0, convert(N_Vector, u0nv))
-        flag = @checkflag CVodeSetUserData(mem, userfun)
-        flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
-        flag = @checkflag CVodeSetMaxNumSteps(mem, maxiter)
-        if Method == :Newton # Only use a linear solver if it's a Newton-based method
-            if LinearSolver == :Dense
-                flag = @checkflag CVDense(mem, length(u0))
-            elseif LinearSolver == :Banded
-                flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
-            elseif LinearSolver == :Diagonal
-                flag = @checkflag CVDiag(mem)
-            elseif LinearSolver == :GMRES
-                flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
-            elseif LinearSolver == :BCG
-                flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
-            elseif LinearSolver == :TFQMR
-                flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
-            end
+    userfun = UserFunctionAndData(f!, userdata)
+    u0nv = NVector(u0)
+    flag = @checkflag CVodeInit(mem,
+                          cfunction(cvodefun, Cint,
+                          (realtype, N_Vector,
+                          N_Vector, Ref{typeof(userfun)})),
+                          t0, convert(N_Vector, u0nv))
+    flag = @checkflag CVodeSetUserData(mem, userfun)
+    flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
+    flag = @checkflag CVodeSetMaxNumSteps(mem, maxiter)
+    if Method == :Newton # Only use a linear solver if it's a Newton-based method
+        if LinearSolver == :Dense
+            flag = @checkflag CVDense(mem, length(u0))
+        elseif LinearSolver == :Banded
+            flag = @checkflag CVBand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+        elseif LinearSolver == :Diagonal
+            flag = @checkflag CVDiag(mem)
+        elseif LinearSolver == :GMRES
+            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+        elseif LinearSolver == :BCG
+            flag = @checkflag CVSpgmr(mem,PREC_NONE,alg.krylov_dim)
+        elseif LinearSolver == :TFQMR
+            flag = @checkflag CVSptfqmr(mem,PREC_NONE,alg.krylov_dim)
         end
+    end
 
-        push!(ures, copy(u0))
-        utmp = NVector(copy(u0))
-        tout = [tspan[1]]
+    push!(ures, copy(u0))
+    utmp = NVector(copy(u0))
+    tout = [tspan[1]]
 
-        # The Inner Loops : Style depends on save_timeseries
-        if save_timeseries
-            for k in 1:length(save_ts)
-                looped = false
-                while tdir*tout[end] < tdir*save_ts[k]
-                    looped = true
-                    flag = @checkflag CVode(mem,
-                                    save_ts[k], utmp, tout, CV_ONE_STEP)
-                    push!(ures,copy(utmp))
-                    push!(ts, tout...)
-                end
-                if looped
-                    # Fix the end
-                    flag = @checkflag CVodeGetDky(
-                                            mem, save_ts[k], Cint(0), ures[end])
-                    ts[end] = save_ts[k]
-                else # Just push another value
-                    flag = @checkflag CVodeGetDky(
-                                            mem, save_ts[k], Cint(0), utmp)
-                    push!(ures,copy(utmp))
-                    push!(ts, save_ts[k]...)
-                end
-            end
-        else # save_timeseries == false, so use CV_NORMAL style
-            for k in 1:length(save_ts)
+    # The Inner Loops : Style depends on save_timeseries
+    if save_timeseries
+        for k in 1:length(save_ts)
+            looped = false
+            while tdir*tout[end] < tdir*save_ts[k]
+                looped = true
                 flag = @checkflag CVode(mem,
-                                    save_ts[k], utmp, tout, CV_NORMAL)
+                                save_ts[k], utmp, tout, CV_ONE_STEP)
+                push!(ures,copy(utmp))
+                push!(ts, tout...)
+            end
+            if looped
+                # Fix the end
+                flag = @checkflag CVodeGetDky(
+                                        mem, save_ts[k], Cint(0), ures[end])
+                ts[end] = save_ts[k]
+            else # Just push another value
+                flag = @checkflag CVodeGetDky(
+                                        mem, save_ts[k], Cint(0), utmp)
                 push!(ures,copy(utmp))
                 push!(ts, save_ts[k]...)
             end
         end
-    finally
-        CVodeFree(Ref{CVODEMemPtr}(mem))
+    else # save_timeseries == false, so use CV_NORMAL style
+        for k in 1:length(save_ts)
+            flag = @checkflag CVode(mem,
+                                save_ts[k], utmp, tout, CV_NORMAL)
+            push!(ures,copy(utmp))
+            push!(ts, save_ts[k]...)
+        end
     end
 
     ### Finishing Routine
@@ -206,7 +202,7 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
                           u = vec(u); du=vec(du); 0)
     end
 
-    mem = IDACreate()
+    mem = Handle(IDACreate())
     if mem == C_NULL
         error("Failed to allocate IDA solver object")
     end
@@ -214,81 +210,77 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
     ures = Vector{Vector{Float64}}()
     ts   = [t0]
 
-    try
-        userfun = UserFunctionAndData(f!, userdata)
-        u0nv = NVector(u0)
-        flag = @checkflag IDAInit(mem, cfunction(idasolfun,
-                                  Cint, (realtype, N_Vector, N_Vector,
-                                  N_Vector, Ref{typeof(userfun)})),
-                                  t0, convert(N_Vector, u0),
-                                  convert(N_Vector, du0))
-        flag = @checkflag IDASetUserData(mem, userfun)
-        flag = @checkflag IDASStolerances(mem, reltol, abstol)
-        flag = @checkflag IDASetMaxNumSteps(mem, maxiter)
-        if LinearSolver == :Dense
-            flag = @checkflag IDADense(mem, length(u0))
-        elseif LinearSolver == :Band
-            flag = @checkflag IDABand(mem,length(u0),alg.jac_upper,alg.jac_lower)
-        elseif LinearSolver == :Diagonal
-            flag = @checkflag IDADiag(mem)
-        elseif LinearSolver == :GMRES
-            flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
-        elseif LinearSolver == :BCG
-            flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
-        elseif LinearSolver == :TFQMR
-            flag = @checkflag IDASptfqmr(mem,PREC_NONE,alg.krylov_dim)
+    userfun = UserFunctionAndData(f!, userdata)
+    u0nv = NVector(u0)
+    flag = @checkflag IDAInit(mem, cfunction(idasolfun,
+                              Cint, (realtype, N_Vector, N_Vector,
+                              N_Vector, Ref{typeof(userfun)})),
+                              t0, convert(N_Vector, u0),
+                              convert(N_Vector, du0))
+    flag = @checkflag IDASetUserData(mem, userfun)
+    flag = @checkflag IDASStolerances(mem, reltol, abstol)
+    flag = @checkflag IDASetMaxNumSteps(mem, maxiter)
+    if LinearSolver == :Dense
+        flag = @checkflag IDADense(mem, length(u0))
+    elseif LinearSolver == :Band
+        flag = @checkflag IDABand(mem,length(u0),alg.jac_upper,alg.jac_lower)
+    elseif LinearSolver == :Diagonal
+        flag = @checkflag IDADiag(mem)
+    elseif LinearSolver == :GMRES
+        flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
+    elseif LinearSolver == :BCG
+        flag = @checkflag IDASpgmr(mem,PREC_NONE,alg.krylov_dim)
+    elseif LinearSolver == :TFQMR
+        flag = @checkflag IDASptfqmr(mem,PREC_NONE,alg.krylov_dim)
+    end
+
+
+    push!(ures, copy(u0))
+    utmp = NVector(copy(u0))
+    dutmp = NVector(copy(u0))
+    tout = [tspan[1]]
+
+    rtest = zeros(length(u0))
+    f!(t0, u0, du0, rtest)
+    if any(abs.(rtest) .>= reltol)
+        if diffstates === nothing
+            error("Must supply diffstates argument to use IDA initial value solver.")
         end
+        flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
+        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[2])
+    end
 
-
-        push!(ures, copy(u0))
-        utmp = NVector(copy(u0))
-        dutmp = NVector(copy(u0))
-        tout = [tspan[1]]
-
-        rtest = zeros(length(u0))
-        f!(t0, u0, du0, rtest)
-        if any(abs.(rtest) .>= reltol)
-            if diffstates === nothing
-                error("Must supply diffstates argument to use IDA initial value solver.")
-            end
-            flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
-            flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[2])
-        end
-
-        # The Inner Loops : Style depends on save_timeseries
-        if save_timeseries
-            for k in 1:length(save_ts)
-                looped = false
-                while tdir*tout[end] < tdir*save_ts[k]
-                    looped = true
-                    flag = @checkflag IDASolve(mem,
-                                    save_ts[k], tout, utmp, dutmp, IDA_ONE_STEP)
-
-                    push!(ures,copy(utmp))
-                    push!(ts, tout...)
-                end
-                if looped
-                    # Fix the end
-                    flag = @checkflag IDAGetDky(
-                                            mem, save_ts[k], Cint(0), ures[end])
-                    ts[end] = save_ts[k]
-                else # Just push another value
-                    flag = @checkflag IDAGetDky(
-                                            mem, save_ts[k], Cint(0), utmp)
-                    push!(ures,copy(utmp))
-                    push!(ts, save_ts[k]...)
-                end
-            end
-        else # save_timeseries == false, so use IDA_NORMAL style
-            for k in 1:length(save_ts)
+    # The Inner Loops : Style depends on save_timeseries
+    if save_timeseries
+        for k in 1:length(save_ts)
+            looped = false
+            while tdir*tout[end] < tdir*save_ts[k]
+                looped = true
                 flag = @checkflag IDASolve(mem,
-                                    save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
+                                save_ts[k], tout, utmp, dutmp, IDA_ONE_STEP)
+
+                push!(ures,copy(utmp))
+                push!(ts, tout...)
+            end
+            if looped
+                # Fix the end
+                flag = @checkflag IDAGetDky(
+                                        mem, save_ts[k], Cint(0), ures[end])
+                ts[end] = save_ts[k]
+            else # Just push another value
+                flag = @checkflag IDAGetDky(
+                                        mem, save_ts[k], Cint(0), utmp)
                 push!(ures,copy(utmp))
                 push!(ts, save_ts[k]...)
             end
         end
-    finally
-        IDAFree(Ref{IDAMemPtr}(mem))
+    else # save_timeseries == false, so use IDA_NORMAL style
+        for k in 1:length(save_ts)
+            flag = @checkflag IDASolve(mem,
+                                save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
+            push!(ures,copy(utmp))
+            push!(ts, save_ts[k]...)
+        end
     end
 
     ### Finishing Routine

--- a/src/common.jl
+++ b/src/common.jl
@@ -60,10 +60,7 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
     end
 
     mem_ptr = CVodeCreate(alg_code, method_code)
-
-    if mem_ptr == C_NULL
-        error("Failed to allocate CVODE solver object")
-    end
+    (mem_ptr == C_NULL) && error("Failed to allocate CVODE solver object")
     mem = Handle(mem_ptr)
 
     ures = Vector{Vector{Float64}}()
@@ -204,9 +201,7 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
     end
 
     mem_ptr = IDACreate()
-    if mem_ptr == C_NULL
-        error("Failed to allocate IDA solver object")
-    end
+    (mem_ptr == C_NULL) && error("Failed to allocate IDA solver object")
     mem = Handle(mem_ptr)
 
     ures = Vector{Vector{Float64}}()

--- a/src/common.jl
+++ b/src/common.jl
@@ -59,11 +59,12 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
         method_code = CV_FUNCTIONAL
     end
 
-    mem = Handle(CVodeCreate(alg_code, method_code))
+    mem_ptr = CVodeCreate(alg_code, method_code)
 
-    if mem == C_NULL
+    if mem_ptr == C_NULL
         error("Failed to allocate CVODE solver object")
     end
+    mem = Handle(mem_ptr)
 
     ures = Vector{Vector{Float64}}()
     ts   = [t0]
@@ -202,10 +203,11 @@ function solve{uType,duType,tType,isinplace,F,LinearSolver}(
                           u = vec(u); du=vec(du); 0)
     end
 
-    mem = Handle(IDACreate())
-    if mem == C_NULL
+    mem_ptr = IDACreate()
+    if mem_ptr == C_NULL
         error("Failed to allocate IDA solver object")
     end
+    mem = Handle(mem_ptr)
 
     ures = Vector{Vector{Float64}}()
     ts   = [t0]

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -33,7 +33,7 @@ immutable Handle{T <: AbstractSundialsObject}
     ptr_ref::Ref{Ptr{T}} # pointer to a pointer
 
     @compat function (::Type{Handle}){T}(ptr::Ptr{T})
-        T <: Void && throw(ArgumentError("Handle assigned to a null pointer"))
+        (ptr == C_NULL) && throw(ArgumentError("Null pointer passed to Handle()"))
         h = new{T}(Ref{Ptr{T}}(ptr))
         finalizer(h.ptr_ref, release_handle)
         return h

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -43,7 +43,7 @@ Base.convert{T}(::Type{Ptr{T}}, h::Handle{T}) = h.ptr_ref[]
 Base.convert{T}(::Type{Ptr{Ptr{T}}}, h::Handle{T}) = convert(Ptr{Ptr{T}}, h.ptr_ref[])
 
 release_handle{T}(ptr_ref::Ref{Ptr{T}}) = throw(MethodError("Freeing objects of type $T not supported"))
-release_handle(ptr_ref::Ref{Ptr{KINMem}}) = KINSOLFree(ptr_ref)
+release_handle(ptr_ref::Ref{Ptr{KINMem}}) = KINFree(ptr_ref)
 release_handle(ptr_ref::Ref{Ptr{CVODEMem}}) = CVodeFree(ptr_ref)
 release_handle(ptr_ref::Ref{Ptr{IDAMem}}) = IDAFree(ptr_ref)
 

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -33,6 +33,7 @@ immutable Handle{T <: AbstractSundialsObject}
     ptr_ref::Ref{Ptr{T}} # pointer to a pointer
 
     @compat function (::Type{Handle}){T}(ptr::Ptr{T})
+        T <: Void && throw(ArgumentError("Handle assigned to a null pointer"))
         h = new{T}(Ref{Ptr{T}}(ptr))
         finalizer(h.ptr_ref, release_handle)
         return h

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -45,10 +45,11 @@ function kinsol(f, y0::Vector{Float64}, userdata::Any = nothing)
     #    where `y` is the input vector, and `fy` is the result of the function
     # y0, Vector of initial values
     # return: the solution vector
-    kmem = Handle(KINCreate())
-    if kmem == C_NULL
+    mem_ptr = KINCreate()
+    if mem_ptr == C_NULL
         error("Failed to allocate KINSOL solver object")
     end
+    kmem = Handle(mem_ptr)
 
     y = copy(y0)
 
@@ -103,13 +104,14 @@ return: a solution matrix with time steps in `t` along rows and
 function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                integrator=:BDF, reltol::Float64=1e-3, abstol::Float64=1e-6, callback=(x,y,z)->true)
     if integrator==:BDF
-        mem = Handle(CVodeCreate(CV_BDF, CV_NEWTON))
+        mem_ptr = CVodeCreate(CV_BDF, CV_NEWTON)
     elseif integrator==:Adams
-        mem = Handle(CVodeCreate(CV_ADAMS, CV_FUNCTIONAL))
+        mem_ptr = CVodeCreate(CV_ADAMS, CV_FUNCTIONAL)
     end
-    if mem == C_NULL
+    if mem_ptr == C_NULL
         error("Failed to allocate CVODE solver object")
     end
+    mem = Handle(mem_ptr)
 
     yres = zeros(length(t), length(y0))
     c = 1
@@ -164,10 +166,11 @@ return: (y,yp) two solution matrices representing the states and state derivativ
 """
 function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                 reltol::Float64=1e-3, abstol::Float64=1e-6, diffstates::Union{Vector{Bool},Void}=nothing)
-    mem = Handle(IDACreate())
-    if mem == C_NULL
+    mem_ptr = IDACreate()
+    if mem_ptr == C_NULL
         error("Failed to allocate IDA solver object")
     end
+    mem = Handle(mem_ptr)
 
     yres = zeros(length(t), length(y0))
     ypres = zeros(length(t), length(y0))

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -46,9 +46,7 @@ function kinsol(f, y0::Vector{Float64}, userdata::Any = nothing)
     # y0, Vector of initial values
     # return: the solution vector
     mem_ptr = KINCreate()
-    if mem_ptr == C_NULL
-        error("Failed to allocate KINSOL solver object")
-    end
+    (mem_ptr == C_NULL) && error("Failed to allocate KINSOL solver object")
     kmem = Handle(mem_ptr)
 
     y = copy(y0)
@@ -108,9 +106,7 @@ function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing
     elseif integrator==:Adams
         mem_ptr = CVodeCreate(CV_ADAMS, CV_FUNCTIONAL)
     end
-    if mem_ptr == C_NULL
-        error("Failed to allocate CVODE solver object")
-    end
+    (mem_ptr == C_NULL) && error("Failed to allocate CVODE solver object")
     mem = Handle(mem_ptr)
 
     yres = zeros(length(t), length(y0))
@@ -167,9 +163,7 @@ return: (y,yp) two solution matrices representing the states and state derivativ
 function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                 reltol::Float64=1e-3, abstol::Float64=1e-6, diffstates::Union{Vector{Bool},Void}=nothing)
     mem_ptr = IDACreate()
-    if mem_ptr == C_NULL
-        error("Failed to allocate IDA solver object")
-    end
+    (mem_ptr == C_NULL) && error("Failed to allocate IDA solver object")
     mem = Handle(mem_ptr)
 
     yres = zeros(length(t), length(y0))


### PR DESCRIPTION
This sets up the high level APIs to use the Handle types. This allows for safer memory usage as this adds a finalizer to the `mem` type, and gets rid of the try/finally setup (which will allow for an eventual integrator interface).

Additionally, there is one fix to the Handles. Kinsol was calling KINSOLfree, instead of KINfree. This was fixed and fixes the finalizer.