### PR TITLE
Use warnings in checkflag on common interface

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -106,11 +106,11 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                                 save_ts[k], utmp, tout, CV_ONE_STEP)
                 push!(ures,copy(utmp))
                 push!(ts, tout...)
-                if flag != 0
+                if flag < 0
                     break
                 end
             end
-            if flag != 0
+            if flag < 0
                 break
             end
             if looped
@@ -124,7 +124,7 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                 push!(ures,copy(utmp))
                 push!(ts, save_ts[k]...)
             end
-            if flag != 0
+            if flag < 0
                 break
             end
         end
@@ -134,7 +134,7 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                                 save_ts[k], utmp, tout, CV_NORMAL)
             push!(ures,copy(utmp))
             push!(ts, save_ts[k]...)
-            if flag != 0
+            if flag < 0
                 break
             end
         end

--- a/src/common.jl
+++ b/src/common.jl
@@ -107,11 +107,11 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                 push!(ures,copy(utmp))
                 push!(ts, tout...)
                 if flag != 0
-                  break
+                    break
                 end
             end
             if flag != 0
-              break
+                break
             end
             if looped
                 # Fix the end
@@ -125,7 +125,7 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                 push!(ts, save_ts[k]...)
             end
             if flag != 0
-              break
+                break
             end
         end
     else # save_timeseries == false, so use CV_NORMAL style
@@ -135,7 +135,7 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
             push!(ures,copy(utmp))
             push!(ts, save_ts[k]...)
             if flag != 0
-              break
+                break
             end
         end
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -106,6 +106,12 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                                 save_ts[k], utmp, tout, CV_ONE_STEP)
                 push!(ures,copy(utmp))
                 push!(ts, tout...)
+                if flag != 0
+                  break
+                end
+            end
+            if flag != 0
+              break
             end
             if looped
                 # Fix the end
@@ -118,6 +124,9 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                 push!(ures,copy(utmp))
                 push!(ts, save_ts[k]...)
             end
+            if flag != 0
+              break
+            end
         end
     else # save_timeseries == false, so use CV_NORMAL style
         for k in 1:length(save_ts)
@@ -125,6 +134,9 @@ function solve{uType,tType,isinplace,F,Method,LinearSolver}(
                                 save_ts[k], utmp, tout, CV_NORMAL)
             push!(ures,copy(utmp))
             push!(ts, save_ts[k]...)
+            if flag != 0
+              break
+            end
         end
     end
 

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -29,12 +29,17 @@ typealias KINMemPtr Ptr{KINMem}
    Manages automatic destruction of the referenced objects when it is
    no longer in use.
 """
-immutable Handle{T <: AbstractSundialsObject}
+immutable Handle{T}
     ptr_ref::Ref{Ptr{T}} # pointer to a pointer
 
-    @compat function (::Type{Handle}){T}(ptr::Ptr{T})
+    @compat function (::Type{Handle}){T<: AbstractSundialsObject}(ptr::Ptr{T})
         (ptr == C_NULL) && throw(ArgumentError("Null pointer passed to Handle()"))
         h = new{T}(Ref{Ptr{T}}(ptr))
+        finalizer(h.ptr_ref, release_handle)
+        return h
+    end
+    @compat function (::Type{Handle})(ptr::Ptr{Void})
+        h = new{Void}(Ref{Ptr{Void}}(ptr))
         finalizer(h.ptr_ref, release_handle)
         return h
     end
@@ -44,9 +49,12 @@ Base.convert{T}(::Type{Ptr{T}}, h::Handle{T}) = h.ptr_ref[]
 Base.convert{T}(::Type{Ptr{Ptr{T}}}, h::Handle{T}) = convert(Ptr{Ptr{T}}, h.ptr_ref[])
 
 release_handle{T}(ptr_ref::Ref{Ptr{T}}) = throw(MethodError("Freeing objects of type $T not supported"))
+release_handle(ptr_ref::Ref{Ptr{Void}}) = nothing
 release_handle(ptr_ref::Ref{Ptr{KINMem}}) = KINFree(ptr_ref)
 release_handle(ptr_ref::Ref{Ptr{CVODEMem}}) = CVodeFree(ptr_ref)
 release_handle(ptr_ref::Ref{Ptr{IDAMem}}) = IDAFree(ptr_ref)
+
+Base.empty!{T}(h::Handle{T}) = release_handle(h.ptr_ref)
 
 ##################################################################
 #

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -14,11 +14,11 @@ macro checkflag(ex,throw_error=false)
     quote
         flag = $(esc(ex))
         if flag != 0
-          if $(esc(throw_error))
-            error($(string(fname, " failed with error code = ")), flag)
-          else
-            warn($(string(fname, " failed with error code = ")), flag)
-          end
+            if $(esc(throw_error))
+                error($(string(fname, " failed with error code = ")), flag)
+            else
+                warn($(string(fname, " failed with error code = ")), flag)
+            end
         end
         flag
     end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -46,8 +46,9 @@ function kinsol(f, y0::Vector{Float64}, userdata::Any = nothing)
     # y0, Vector of initial values
     # return: the solution vector
     mem_ptr = KINCreate()
-    (mem_ptr == C_NULL) && error("Failed to allocate KINSOL solver object")
     kmem = Handle(mem_ptr)
+    (mem_ptr == C_NULL) && (empty!(kmem);error("Failed to allocate KINSOL solver object"))
+
 
     y = copy(y0)
 
@@ -62,6 +63,7 @@ function kinsol(f, y0::Vector{Float64}, userdata::Any = nothing)
     strategy = KIN_NONE
     flag = @checkflag KINSol(kmem, y, strategy, scale, scale)
 
+    empty!(kmem)
 
     return y
 end
@@ -106,8 +108,8 @@ function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing
     elseif integrator==:Adams
         mem_ptr = CVodeCreate(CV_ADAMS, CV_FUNCTIONAL)
     end
-    (mem_ptr == C_NULL) && error("Failed to allocate CVODE solver object")
     mem = Handle(mem_ptr)
+    (mem_ptr == C_NULL) && (empty!(mem);error("Failed to allocate CVODE solver object"))
 
     yres = zeros(length(t), length(y0))
     c = 1
@@ -129,6 +131,8 @@ function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing
         yres[k,:] = convert(Vector, ynv)
         c = c + 1
     end
+
+    empty!(mem)
 
     return yres[1:c,:]
 end
@@ -163,8 +167,8 @@ return: (y,yp) two solution matrices representing the states and state derivativ
 function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing;
                 reltol::Float64=1e-3, abstol::Float64=1e-6, diffstates::Union{Vector{Bool},Void}=nothing)
     mem_ptr = IDACreate()
-    (mem_ptr == C_NULL) && error("Failed to allocate IDA solver object")
     mem = Handle(mem_ptr)
+    (mem_ptr == C_NULL) && (empty!(mem);error("Failed to allocate IDA solver object"))
 
     yres = zeros(length(t), length(y0))
     ypres = zeros(length(t), length(y0))
@@ -194,6 +198,8 @@ function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}
         yres[k,:] = y
         ypres[k,:] = yp
     end
+
+    empty!(mem)
 
     return yres, ypres
 end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -8,13 +8,17 @@
     Insert a check that the given function call returns 0,
     throw an error otherwise. Only apply directly to function calls.
 """
-macro checkflag(ex)
+macro checkflag(ex,throw_error=false)
     @assert Base.Meta.isexpr(ex, :call)
     fname = ex.args[1]
     quote
         flag = $(esc(ex))
         if flag != 0
+          if $(esc(throw_error))
             error($(string(fname, " failed with error code = ")), flag)
+          else
+            warn($(string(fname, " failed with error code = ")), flag)
+          end
         end
         flag
     end
@@ -55,13 +59,13 @@ function kinsol(f, y0::Vector{Float64}, userdata::Any = nothing)
     # use the user_data field to pass a function
     #   see: https://github.com/JuliaLang/julia/issues/2554
     userfun = UserFunctionAndData(f, userdata)
-    flag = @checkflag KINInit(kmem, cfunction(kinsolfun, Cint, (N_Vector, N_Vector, Ref{typeof(userfun)})), NVector(y0))
-    flag = @checkflag KINDense(kmem, length(y0))
-    flag = @checkflag KINSetUserData(kmem, userfun)
+    flag = @checkflag KINInit(kmem, cfunction(kinsolfun, Cint, (N_Vector, N_Vector, Ref{typeof(userfun)})), NVector(y0)) true
+    flag = @checkflag KINDense(kmem, length(y0)) true
+    flag = @checkflag KINSetUserData(kmem, userfun) true
     ## Solve problem
     scale = ones(length(y0))
     strategy = KIN_NONE
-    flag = @checkflag KINSol(kmem, y, strategy, scale, scale)
+    flag = @checkflag KINSol(kmem, y, strategy, scale, scale) true
 
     empty!(kmem)
 
@@ -116,15 +120,15 @@ function cvode(f, y0::Vector{Float64}, t::Vector{Float64}, userdata::Any=nothing
 
     userfun = UserFunctionAndData(f, userdata)
     y0nv = NVector(y0)
-    flag = @checkflag CVodeInit(mem, cfunction(cvodefun, Cint, (realtype, N_Vector, N_Vector, Ref{typeof(userfun)})), t[1], convert(N_Vector, y0nv))
-    flag = @checkflag CVodeSetUserData(mem, userfun)
-    flag = @checkflag CVodeSStolerances(mem, reltol, abstol)
-    flag = @checkflag CVDense(mem, length(y0))
+    flag = @checkflag CVodeInit(mem, cfunction(cvodefun, Cint, (realtype, N_Vector, N_Vector, Ref{typeof(userfun)})), t[1], convert(N_Vector, y0nv)) true
+    flag = @checkflag CVodeSetUserData(mem, userfun) true
+    flag = @checkflag CVodeSStolerances(mem, reltol, abstol) true
+    flag = @checkflag CVDense(mem, length(y0)) true
     yres[1,:] = y0
     ynv = NVector(copy(y0))
     tout = [0.0]
     for k in 2:length(t)
-        flag = @checkflag CVode(mem, t[k], ynv, tout, CV_NORMAL)
+        flag = @checkflag CVode(mem, t[k], ynv, tout, CV_NORMAL) true
         if !callback(mem, t[k], ynv)
             break
         end
@@ -175,18 +179,18 @@ function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}
 
     userfun = UserFunctionAndData(f, userdata)
     flag = @checkflag IDAInit(mem, cfunction(idasolfun, Cint, (realtype, N_Vector, N_Vector, N_Vector, Ref{typeof(userfun)})),
-                              t[1], y0, yp0)
-    flag = @checkflag IDASetUserData(mem, userfun)
-    flag = @checkflag IDASStolerances(mem, reltol, abstol)
-    flag = @checkflag IDADense(mem, length(y0))
+                              t[1], y0, yp0) true
+    flag = @checkflag IDASetUserData(mem, userfun) true
+    flag = @checkflag IDASStolerances(mem, reltol, abstol) true
+    flag = @checkflag IDADense(mem, length(y0)) true
     rtest = zeros(length(y0))
     f(t[1], y0, yp0, rtest)
     if any(abs.(rtest) .>= reltol)
         if diffstates === nothing
             error("Must supply diffstates argument to use IDA initial value solver.")
         end
-        flag = @checkflag IDASetId(mem, collect(Float64, diffstates))
-        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, t[2])
+        flag = @checkflag IDASetId(mem, collect(Float64, diffstates)) true
+        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, t[2]) true
     end
     yres[1,:] = y0
     ypres[1,:] = yp0
@@ -194,7 +198,7 @@ function idasol(f, y0::Vector{Float64}, yp0::Vector{Float64}, t::Vector{Float64}
     yp = copy(yp0)
     tout = [0.0]
     for k in 2:length(t)
-        retval = @checkflag IDASolve(mem, t[k], tout, y, yp, IDA_NORMAL)
+        retval = @checkflag IDASolve(mem, t[k], tout, y, yp, IDA_NORMAL) true
         yres[k,:] = y
         ypres[k,:] = yp
     end


### PR DESCRIPTION
Instead of throwing a Julia error, the common interface will now warn. This makes Sundials compatible with the addon functionality like parameter estimation which can choose parameters that diverge. Before, this would make Sundials throw an error, which would error the higher level routine. Now it will return the current solution at the time of the error, which the parameter estimation techniques know how to handle.