### PR TITLE
Make @checkflag not fail on CV_ROOT_RETURN.

### DIFF
--- a/src/simple.jl
+++ b/src/simple.jl
@@ -13,7 +13,7 @@ macro checkflag(ex)
     fname = ex.args[1]
     quote
         flag = $(esc(ex))
-        if flag != 0
+        if flag < 0
             error($(string(fname, " failed with error code = ")), flag)
         end
         flag


### PR DESCRIPTION
Positive return codes are not errors.

In particular, CV_ROOT_RETURN is a pretty normal successful return code.
