### PR TITLE
common interface update

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps 0.4.3
 Compat 0.9.0
-DiffEqBase 0.2.0
+DiffEqBase 0.15.0

--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -3,44 +3,49 @@ using DiffEqProblemLibrary, DiffEqBase, Sundials
 prob = prob_ode_linear
 dt = 1//2^(4)
 saveat = float(collect(0:dt:1))
-@time sol = solve(prob,CVODE_BDF())
-@time sol = solve(prob,CVODE_Adams())
-@time sol = solve(prob,CVODE_Adams(),saveat=saveat)
-
-@test intersect(sol.t,saveat) == saveat
-
-@time sol = solve(prob,CVODE_Adams(),saveat=saveat,save_timeseries=false)
+sol = solve(prob,CVODE_BDF())
+sol = solve(prob,CVODE_Adams())
+sol = solve(prob,CVODE_Adams(),saveat=saveat)
 
 @test sol.t == saveat
 
-prob = prob_ode_2Dlinear
-@time sol = solve(prob,CVODE_BDF())
-@time sol = solve(prob,CVODE_Adams())
-@time sol = solve(prob,CVODE_Adams(),saveat=saveat)
+sol = solve(prob,CVODE_Adams(),saveat=dt)
 
+@test sol.t == saveat
+
+sol = solve(prob,CVODE_Adams(),saveat=saveat,save_everystep=true)
+
+@test sol.t != saveat
 @test intersect(sol.t,saveat) == saveat
 
-@time sol = solve(prob,CVODE_Adams(),saveat=saveat,save_timeseries=false)
+prob = prob_ode_2Dlinear
+sol = solve(prob,CVODE_BDF())
+sol = solve(prob,CVODE_Adams())
+sol = solve(prob,CVODE_Adams(),saveat=saveat)
+
+@test sol.t == saveat
+
+sol = solve(prob,CVODE_Adams(),saveat=saveat,save_everystep=false)
 
 @test sol.t == saveat
 
 # Test the other function conversions
 k = (t,u,du) -> du[1] = u[1]
 prob = ODEProblem(k,[1.0],(0.0,1.0))
-@time sol = solve(prob,CVODE_BDF())
+sol = solve(prob,CVODE_BDF())
 h = (t,u) -> u
 u0 = [1.0 2.0
       3.0 2.0]
 prob = ODEProblem(h,u0,(0.0,1.0))
-@time sol = solve(prob,CVODE_BDF())
+sol = solve(prob,CVODE_BDF())
 
 # Test Algorithm Choices
-@time sol1 = solve(prob,CVODE_BDF(method=:Functional))
-@time sol2 = solve(prob,CVODE_BDF(linear_solver=:Banded,jac_upper=3,jac_lower=3))
-@time sol3 = solve(prob,CVODE_BDF(linear_solver=:Diagonal))
-@time sol4 = solve(prob,CVODE_BDF(linear_solver=:GMRES))
-@time sol5 = solve(prob,CVODE_BDF(linear_solver=:BCG))
-@time sol6 = solve(prob,CVODE_BDF(linear_solver=:TFQMR))
+sol1 = solve(prob,CVODE_BDF(method=:Functional))
+sol2 = solve(prob,CVODE_BDF(linear_solver=:Banded,jac_upper=3,jac_lower=3))
+sol3 = solve(prob,CVODE_BDF(linear_solver=:Diagonal))
+sol4 = solve(prob,CVODE_BDF(linear_solver=:GMRES))
+sol5 = solve(prob,CVODE_BDF(linear_solver=:BCG))
+sol6 = solve(prob,CVODE_BDF(linear_solver=:TFQMR))
 
 @test isapprox(sol1[end],sol2[end],rtol=1e-3)
 @test isapprox(sol1[end],sol3[end],rtol=1e-3)
@@ -61,11 +66,12 @@ saveat = float(collect(0:dt:100000))
 sol = solve(prob,IDA())
 sol = solve(prob,IDA(),saveat=saveat)
 
-@test intersect(sol.t,saveat) == saveat
-
-sol = solve(prob,IDA(),saveat=saveat,save_timeseries=false)
-
 @test sol.t == saveat
+
+sol = solve(prob,IDA(),saveat=saveat,save_everystep=true)
+
+@test sol.t != saveat
+@test intersect(sol.t,saveat) == saveat
 
 prob = deepcopy(prob_dae_resrob)
 prob.tspan = (1.0,0.0)

--- a/examples/common_interface.jl
+++ b/examples/common_interface.jl
@@ -18,6 +18,10 @@ sol = solve(prob,CVODE_Adams(),saveat=saveat,save_everystep=true)
 @test sol.t != saveat
 @test intersect(sol.t,saveat) == saveat
 
+sol = solve(prob,CVODE_Adams(),saveat=saveat,save_everystep=true,save_start=false)
+
+@test sol.t[1] != 0
+
 prob = prob_ode_2Dlinear
 sol = solve(prob,CVODE_BDF())
 sol = solve(prob,CVODE_Adams())

--- a/src/common.jl
+++ b/src/common.jl
@@ -7,6 +7,7 @@ function solve{uType, tType, isinplace, Method, LinearSolver}(
     callback=()->nothing, abstol=1/10^6, reltol=1/10^3,
     saveat=Float64[], adaptive=true, maxiter=Int(1e5),
     timeseries_errors=true, save_everystep=isempty(saveat),
+    save_start = true,
     save_timeseries = nothing,
     userdata=nothing, kwargs...)
 
@@ -74,7 +75,7 @@ function solve{uType, tType, isinplace, Method, LinearSolver}(
     mem = Handle(mem_ptr)
 
     ures = Vector{Vector{Float64}}()
-    ts   = [t0]
+    save_start ? ts = [t0] : ts = Float64[]
 
     userfun = UserFunctionAndData(f!, userdata)
     u0nv = NVector(u0)
@@ -102,7 +103,7 @@ function solve{uType, tType, isinplace, Method, LinearSolver}(
         end
     end
 
-    push!(ures, copy(u0))
+    save_start && push!(ures, copy(u0))
     utmp = NVector(copy(u0))
     tout = [tspan[1]]
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,29 +1,40 @@
 ## Common Interface Solve Functions
 
-function solve{uType, tType, isinplace, F, Method, LinearSolver}(
-    prob::AbstractODEProblem{uType, tType, isinplace, F},
+function solve{uType, tType, isinplace, Method, LinearSolver}(
+    prob::AbstractODEProblem{uType, tType, isinplace},
     alg::SundialsODEAlgorithm{Method,LinearSolver},
     timeseries=[], ts=[], ks=[];
     callback=()->nothing, abstol=1/10^6, reltol=1/10^3,
     saveat=Float64[], adaptive=true, maxiter=Int(1e5),
-    timeseries_errors=true, save_timeseries=true,
+    timeseries_errors=true, save_everystep=isempty(saveat),
+    save_timeseries = nothing,
     userdata=nothing, kwargs...)
+
+    if save_timeseries != nothing
+        warn("save_timeseries is deprecated. Use save_everystep instead")
+        save_everystep = save_timeseries
+    end
 
     tspan = prob.tspan
     t0 = tspan[1]
 
     tdir = sign(tspan[2]-tspan[1])
 
-    if !isempty(saveat) && saveat[1] == tspan[1]
-      save_ts = @view saveat[2:end]
+    if typeof(saveat) <: Number
+      saveat_vec = convert(Vector{tType},saveat:saveat:(tspan[end]-saveat))
+      # Exclude the endpoint because of floating point issues
     else
-      save_ts = saveat
+      saveat_vec =  convert(Vector{tType},collect(saveat))
     end
 
-    if !isempty(save_ts) && save_ts[end] != tspan[2]
-      push!(save_ts, tspan[2])
-    elseif isempty(save_ts)
-      save_ts = [tspan[2]]
+    if !isempty(saveat_vec) && saveat_vec[end] == tspan[2]
+      pop!(saveat_vec)
+    end
+
+    if !isempty(saveat_vec) && saveat_vec[1] == tspan[1]
+      save_ts = sort(unique([saveat_vec[2:end];tspan[2]]))
+    else
+      save_ts = sort(unique([saveat_vec;tspan[2]]))
     end
 
     if typeof(prob.u0) <: Number
@@ -95,8 +106,8 @@ function solve{uType, tType, isinplace, F, Method, LinearSolver}(
     utmp = NVector(copy(u0))
     tout = [tspan[1]]
 
-    # The Inner Loops : Style depends on save_timeseries
-    if save_timeseries
+    # The Inner Loops : Style depends on save_everystep
+    if save_everystep
         for k in 1:length(save_ts)
             looped = false
             while tdir*tout[end] < tdir*save_ts[k]
@@ -121,7 +132,7 @@ function solve{uType, tType, isinplace, F, Method, LinearSolver}(
             end
             (flag < 0) && break
         end
-    else # save_timeseries == false, so use CV_NORMAL style
+    else # save_everystep == false, so use CV_NORMAL style
         for k in 1:length(save_ts)
             flag = @checkflag CVode(mem,
                                 save_ts[k], utmp, tout, CV_NORMAL)
@@ -147,35 +158,47 @@ function solve{uType, tType, isinplace, F, Method, LinearSolver}(
     empty!(mem);
 
     build_solution(prob, alg, ts, timeseries,
-                      timeseries_errors = timeseries_errors)
+                      timeseries_errors = timeseries_errors,
+                      retcode = :Success)
 end
 
 ## Solve for DAEs uses IDA
 
-function solve{uType, duType, tType, isinplace, F, LinearSolver}(
-    prob::AbstractDAEProblem{uType, duType, tType, isinplace, F},
+function solve{uType, duType, tType, isinplace, LinearSolver}(
+    prob::AbstractDAEProblem{uType, duType, tType, isinplace},
     alg::SundialsDAEAlgorithm{LinearSolver},
     timeseries=[], ts=[], ks=[];
     callback=()->nothing, abstol=1/10^6, reltol=1/10^3,
     saveat=Float64[], adaptive=true, maxiter=Int(1e5),
-    timeseries_errors=true, save_timeseries=true,
+    timeseries_errors=true, save_everystep=isempty(saveat),
+    save_timeseries = nothing,
     userdata=nothing, kwargs...)
+
+    if save_timeseries != nothing
+        warn("save_timeseries is deprecated. Use save_everystep instead")
+        save_everystep = save_timeseries
+    end
 
     tspan = prob.tspan
     t0 = tspan[1]
 
     tdir = sign(tspan[2]-tspan[1])
 
-    if !isempty(saveat) && saveat[1] == tspan[1]
-      save_ts = @view saveat[2:end]
+    if typeof(saveat) <: Number
+      saveat_vec = convert(Vector{tType},saveat:saveat:(tspan[end]-saveat))
+      # Exclude the endpoint because of floating point issues
     else
-      save_ts = saveat
+      saveat_vec =  convert(Vector{tType},collect(saveat))
     end
 
-    if !isempty(save_ts) && save_ts[end] != tspan[2]
-      push!(save_ts,tspan[2])
-    elseif isempty(save_ts)
-      save_ts = [tspan[2]]
+    if !isempty(saveat_vec) && saveat_vec[end] == tspan[2]
+      pop!(saveat_vec)
+    end
+
+    if !isempty(saveat_vec) && saveat_vec[1] == tspan[1]
+      save_ts = sort(unique([saveat_vec[2:end];tspan[2]]))
+    else
+      save_ts = sort(unique([saveat_vec;tspan[2]]))
     end
 
     if typeof(prob.u0) <: Number
@@ -252,8 +275,8 @@ function solve{uType, duType, tType, isinplace, F, LinearSolver}(
         flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[2])
     end
 
-    # The Inner Loops : Style depends on save_timeseries
-    if save_timeseries
+    # The Inner Loops : Style depends on save_everystep
+    if save_everystep
         for k in 1:length(save_ts)
             looped = false
             while tdir*tout[end] < tdir*save_ts[k]
@@ -278,7 +301,7 @@ function solve{uType, duType, tType, isinplace, F, LinearSolver}(
             end
             (flag < 0) && break
         end
-    else # save_timeseries == false, so use IDA_NORMAL style
+    else # save_everystep == false, so use IDA_NORMAL style
         for k in 1:length(save_ts)
             flag = @checkflag IDASolve(mem,
                                 save_ts[k], tout, utmp, dutmp, IDA_NORMAL)
@@ -304,5 +327,6 @@ function solve{uType, duType, tType, isinplace, F, LinearSolver}(
     empty!(mem);
 
     build_solution(prob, alg, ts, timeseries,
-                      timeseries_errors = timeseries_errors)
+                      timeseries_errors = timeseries_errors,
+                      retcode = :Success)
 end


### PR DESCRIPTION
This updates the common interface to the new specs for DiffEqBase.jl's v0.15.0. It is incompatible with previous versions. This should not be merged until DiffEqBase.jl v0.15.0 is released, and upper bounds are placed in METADATA.