### PR TITLE
Add integrator interface, callbacks and event handling

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6.1
 BinDeps 0.4.3
 DiffEqBase 1.5.1
 Reexport

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ BinDeps 0.4.3
 DiffEqBase 1.5.1
 Reexport
 DataStructures
+Roots

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 BinDeps 0.4.3
 DiffEqBase 1.5.1
 Reexport
+DataStructures

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6.1
+julia 0.6.0
 BinDeps 0.4.3
 DiffEqBase 1.5.1
 Reexport

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module Sundials
 
-using Reexport
+using Reexport, DataStructures
 @reexport using DiffEqBase
 import DiffEqBase: solve
 

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -54,6 +54,8 @@ include("kinsol.jl")
 
 include("simple.jl")
 include("common_interface/integrator_types.jl")
+include("common_interface/integrator_utils.jl")
+include("common_interface/callbacks.jl")
 include("common_interface/algorithms.jl")
 include("common_interface/solve.jl")
 

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module Sundials
 
-using Reexport, DataStructures
+using Reexport, DataStructures, Roots
 @reexport using DiffEqBase
 import DiffEqBase: solve
 

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -53,6 +53,7 @@ end
 include("kinsol.jl")
 
 include("simple.jl")
+include("common_interface/integrator_types.jl")
 include("common_interface/algorithms.jl")
 include("common_interface/solve.jl")
 

--- a/src/common_interface/callbacks.jl
+++ b/src/common_interface/callbacks.jl
@@ -1,0 +1,195 @@
+# Use Recursion to find the first callback for type-stability
+
+# Base Case: Only one callback
+function find_first_continuous_callback(integrator, callback::AbstractContinuousCallback)
+  (find_callback_time(integrator,callback)...,1,1)
+end
+
+# Starting Case: Compute on the first callback
+function find_first_continuous_callback(integrator, callback::AbstractContinuousCallback, args...)
+  find_first_continuous_callback(integrator,find_callback_time(integrator,callback)...,1,1,args...)
+end
+
+function find_first_continuous_callback(integrator,tmin::Number,upcrossing::Float64,idx::Int,counter::Int,callback2)
+  counter += 1 # counter is idx for callback2.
+  tmin2,upcrossing2 = find_callback_time(integrator,callback2)
+
+  if (tmin2 < tmin && tmin2 != zero(typeof(tmin))) || tmin == zero(typeof(tmin))
+    return tmin2,upcrossing,counter,counter
+  else
+    return tmin,upcrossing,idx,counter
+  end
+end
+
+function find_first_continuous_callback(integrator,tmin::Number,upcrossing::Float64,idx::Int,counter::Int,callback2,args...)
+  find_first_continuous_callback(integrator,find_first_continuous_callback(integrator,tmin,upcrossing,idx,counter,callback2)...,args...)
+end
+
+@inline function determine_event_occurance(integrator,callback)
+  event_occurred = false
+  if callback.interp_points!=0
+    ode_addsteps!(integrator)
+  end
+  Θs = linspace(typeof(integrator.t)(0),typeof(integrator.t)(1),callback.interp_points)
+  interp_index = 0
+  # Check if the event occured
+  if typeof(callback.idxs) <: Void
+    previous_condition = callback.condition(integrator.tprev,integrator.uprev,integrator)
+  elseif typeof(callback.idxs) <: Number
+    previous_condition = callback.condition(integrator.tprev,integrator.uprev[callback.idxs],integrator)
+  else
+    previous_condition = callback.condition(integrator.tprev,@view(integrator.uprev[callback.idxs]),integrator)
+  end
+  if isapprox(previous_condition,0,rtol=callback.reltol,atol=callback.abstol)
+    prev_sign = 0.0
+  else
+    prev_sign = sign(previous_condition)
+  end
+  prev_sign_index = 1
+  if typeof(callback.idxs) <: Void
+    next_sign = sign(callback.condition(integrator.t,integrator.u,integrator))
+  elseif typeof(callback.idxs) <: Number
+    next_sign = sign(callback.condition(integrator.t,integrator.u[callback.idxs],integrator))
+  else
+    next_sign = sign(callback.condition(integrator.t,@view(integrator.u[callback.idxs]),integrator))
+  end
+  if ((prev_sign<0 && !(typeof(callback.affect!)<:Void)) || (prev_sign>0 && !(typeof(callback.affect_neg!)<:Void))) && prev_sign*next_sign<=0
+    event_occurred = true
+    interp_index = callback.interp_points
+  elseif callback.interp_points!=0  && !(typeof(integrator.alg) <: Discrete)# Use the interpolants for safety checking
+    tmp = integrator.tmp
+    for i in 2:length(Θs)-1
+      if !(typeof(callback.idxs) <: Number)
+        integrator(tmp,integrator.tprev+Θs[i])
+        _tmp = @view tmp[callback.idxs]
+      else
+        _tmp = integrator(integrator.tprev+Θs[i])[callback.idxs]
+      end
+      new_sign = callback.condition(integrator.tprev+integrator.dt*Θs[i],_tmp,integrator)
+      if prev_sign == 0
+        prev_sign = new_sign
+        prev_sign_index = i
+      end
+      if ((prev_sign<0 && !(typeof(callback.affect!)<:Void)) || (prev_sign>0 && !(typeof(callback.affect_neg!)<:Void))) && prev_sign*new_sign<0
+        event_occurred = true
+        interp_index = i
+        break
+      end
+    end
+  end
+  event_occurred,interp_index,Θs,prev_sign,prev_sign_index
+end
+
+function find_callback_time(integrator,callback)
+  event_occurred,interp_index,Θs,prev_sign,prev_sign_index = determine_event_occurance(integrator,callback)
+  if event_occurred
+    if typeof(callback.condition) <: Void
+      new_t = zero(typeof(integrator.t))
+    else
+      if callback.interp_points!=0
+        top_Θ = Θs[interp_index] # Top at the smallest
+      else
+        top_Θ = typeof(integrator.t)(1)
+      end
+      if callback.rootfind && !(typeof(integrator.alg) <: Discrete)
+        tmp = integrator.tmp
+        find_zero = (Θ) -> begin
+          if !(typeof(callback.idxs) <: Number)
+            integrator(tmp,integrator.tprev+θ)
+            _tmp = @view tmp[callback.idxs]
+          else
+            _tmp = integrator(integrator.tprev+Θ)[callback.idxs]
+          end
+          callback.condition(integrator.tprev+Θ*integrator.dt,tmp,integrator)
+        end
+        Θ = prevfloat(prevfloat(fzero(find_zero,Θs[prev_sign_index],top_Θ)))
+        # 2 prevfloat guerentees that the new time is either 1 or 2 floating point
+        # numbers just before the event, but not after. If there's a barrier
+        # which is never supposed to be crossed, then this will ensure that
+        # The item never leaves the domain. Otherwise Roots.jl can return
+        # a float which is slightly after, making it out of the domain, causing
+        # havoc.
+        new_t = integrator.dt*Θ
+      elseif interp_index != callback.interp_points && !(typeof(integrator.alg) <: Discrete)
+        new_t = integrator.dt*Θs[interp_index]
+      else
+        # If no solve and no interpolants, just use endpoint
+        new_t = integrator.dt
+      end
+    end
+  else
+    new_t = zero(typeof(integrator.t))
+  end
+  new_t,prev_sign
+end
+
+function apply_callback!(integrator,callback::ContinuousCallback,cb_time,prev_sign)
+  if cb_time != zero(typeof(integrator.t))
+    integrator.t = integrator.tprev+cb_time
+    integrator(integrator.u,integrator.t)
+  end
+  saved_in_cb = false
+
+  @inbounds if callback.save_positions[1]
+    savevalues!(integrator,true)
+    saved_in_cb = true
+  end
+
+  integrator.u_modified = true
+
+  if prev_sign < 0
+    if typeof(callback.affect!) <: Void
+      integrator.u_modified = false
+    else
+      callback.affect!(integrator)
+    end
+  elseif prev_sign > 0
+    if typeof(callback.affect_neg!) <: Void
+      integrator.u_modified = false
+    else
+      callback.affect_neg!(integrator)
+    end
+  end
+
+  if integrator.u_modified
+    @inbounds if callback.save_positions[2]
+      savevalues!(integrator,true)
+      saved_in_cb = true
+    end
+    return true,saved_in_cb
+  end
+  false,saved_in_cb
+end
+
+#Base Case: Just one
+@inline function apply_discrete_callback!(integrator,callback::DiscreteCallback)
+  saved_in_cb = false
+  if callback.condition(integrator.t,integrator.u,integrator)
+    @inbounds if callback.save_positions[1]
+      savevalues!(integrator,true)
+      saved_in_cb = true
+    end
+    integrator.u_modified = true
+    callback.affect!(integrator)
+    @inbounds if callback.save_positions[2]
+      savevalues!(integrator,true)
+      saved_in_cb = true
+    end
+  end
+  integrator.u_modified,saved_in_cb
+end
+
+#Starting: Get bool from first and do next
+@inline function apply_discrete_callback!(integrator,callback::DiscreteCallback,args...)
+  apply_discrete_callback!(integrator,apply_discrete_callback!(integrator,callback)...,args...)
+end
+
+@inline function apply_discrete_callback!(integrator,discrete_modified::Bool,saved_in_cb::Bool,callback::DiscreteCallback,args...)
+  bool,saved_in_cb2 = apply_discrete_callback!(integrator,apply_discrete_callback!(integrator,callback)...,args...)
+  discrete_modified || bool, saved_in_cb || saved_in_cb2
+end
+
+@inline function apply_discrete_callback!(integrator,discrete_modified::Bool,saved_in_cb::Bool,callback::DiscreteCallback)
+  bool,saved_in_cb2 = apply_discrete_callback!(integrator,callback)
+  discrete_modified || bool, saved_in_cb || saved_in_cb2
+end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -1,11 +1,13 @@
-mutable struct SundialsIntegrator{uType,tType,memType,solType,algType,fType,oType} <: AbstractODEIntegrator
+mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType} <: AbstractODEIntegrator
     u::uType
-    t::tType
+    t::Float64
     mem::memType
     sol::solType
     alg::algType
     f::fType
     opts::oType
+    tout::toutType
+    tdir::Float64
 end
 
 mutable struct DEOptions{SType,TstopType}
@@ -13,4 +15,6 @@ mutable struct DEOptions{SType,TstopType}
     tstops::TstopType
     save_everystep::Bool
     dense::Bool
+    timeseries_errors::Bool
+    dense_errors::Bool
 end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -1,4 +1,4 @@
-mutable struct DEOptions{SType,TstopType}
+mutable struct DEOptions{SType,TstopType,CType}
     saveat::SType
     tstops::TstopType
     save_everystep::Bool
@@ -6,11 +6,13 @@ mutable struct DEOptions{SType,TstopType}
     timeseries_errors::Bool
     dense_errors::Bool
     save_end::Bool
+    callbacks::CType
 end
 
-mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType,sizeType} <: AbstractODEIntegrator
+mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType,sizeType,tmpType} <: AbstractODEIntegrator
     u::uType
     t::Float64
+    tprev::Float64
     mem::memType
     sol::solType
     alg::algType
@@ -19,6 +21,8 @@ mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,tout
     tout::toutType
     tdir::Float64
     sizeu::sizeType
+    u_modified::Bool
+    tmp::tmpType
 end
 
 function (integrator::SundialsIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -9,7 +9,9 @@ mutable struct DEOptions{SType,TstopType,CType}
     callback::CType
 end
 
-mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,JType,oType,toutType,sizeType,tmpType} <: AbstractODEIntegrator
+abstract type AbstractSundialsIntegrator <: AbstractODEIntegrator end
+
+mutable struct CVODEIntegrator{uType,memType,solType,algType,fType,JType,oType,toutType,sizeType,tmpType} <: AbstractSundialsIntegrator
     u::uType
     t::Float64
     tprev::Float64
@@ -27,13 +29,13 @@ mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,JType,oTyp
     uprev::tmpType
 end
 
-function (integrator::SundialsIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T
+function (integrator::CVODEIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T
     out = similar(integrator.u)
     CVodeGetDky(integrator.mem, t, Cint(T), out)
     out
 end
 
-function (integrator::SundialsIntegrator)(out,t::Number,
+function (integrator::CVODEIntegrator)(out,t::Number,
                                           deriv::Type{Val{T}}=Val{0}) where T
     CVodeGetDky(integrator.mem, t, Cint(T), out)
 end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -18,4 +18,5 @@ mutable struct DEOptions{SType,TstopType}
     dense::Bool
     timeseries_errors::Bool
     dense_errors::Bool
+    save_end::Bool
 end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -6,7 +6,7 @@ mutable struct DEOptions{SType,TstopType,CType}
     timeseries_errors::Bool
     dense_errors::Bool
     save_end::Bool
-    callbacks::CType
+    callback::CType
 end
 
 mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType,sizeType,tmpType} <: AbstractODEIntegrator
@@ -23,6 +23,7 @@ mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,tout
     sizeu::sizeType
     u_modified::Bool
     tmp::tmpType
+    uprev::tmpType
 end
 
 function (integrator::SundialsIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -1,0 +1,16 @@
+mutable struct SundialsIntegrator{uType,tType,memType,solType,algType,fType,oType} <: AbstractODEIntegrator
+    u::uType
+    t::tType
+    mem::memType
+    sol::solType
+    alg::algType
+    f::fType
+    opts::oType
+end
+
+mutable struct DEOptions{SType,TstopType}
+    saveat::SType
+    tstops::TstopType
+    save_everystep::Bool
+    dense::Bool
+end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -1,3 +1,13 @@
+mutable struct DEOptions{SType,TstopType}
+    saveat::SType
+    tstops::TstopType
+    save_everystep::Bool
+    dense::Bool
+    timeseries_errors::Bool
+    dense_errors::Bool
+    save_end::Bool
+end
+
 mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType,sizeType} <: AbstractODEIntegrator
     u::uType
     t::Float64
@@ -11,12 +21,13 @@ mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,tout
     sizeu::sizeType
 end
 
-mutable struct DEOptions{SType,TstopType}
-    saveat::SType
-    tstops::TstopType
-    save_everystep::Bool
-    dense::Bool
-    timeseries_errors::Bool
-    dense_errors::Bool
-    save_end::Bool
+function (integrator::SundialsIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T
+    out = similar(integrator.u)
+    CVodeGetDky(integrator.mem, t, Cint(T), out)
+    out
+end
+
+function (integrator::SundialsIntegrator)(out,t::Number,
+                                          deriv::Type{Val{T}}=Val{0}) where T
+    CVodeGetDky(integrator.mem, t, Cint(T), out)
 end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -9,7 +9,7 @@ mutable struct DEOptions{SType,TstopType,CType}
     callback::CType
 end
 
-mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType,sizeType,tmpType} <: AbstractODEIntegrator
+mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,JType,oType,toutType,sizeType,tmpType} <: AbstractODEIntegrator
     u::uType
     t::Float64
     tprev::Float64
@@ -17,6 +17,7 @@ mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,tout
     sol::solType
     alg::algType
     f::fType
+    jac::JType
     opts::oType
     tout::toutType
     tdir::Float64

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -11,7 +11,7 @@ end
 
 abstract type AbstractSundialsIntegrator <: AbstractODEIntegrator end
 
-mutable struct CVODEIntegrator{uType,memType,solType,algType,fType,JType,oType,toutType,sizeType,tmpType} <: AbstractSundialsIntegrator
+mutable struct CVODEIntegrator{uType,memType,solType,algType,fType,UFType,JType,oType,toutType,sizeType,tmpType} <: AbstractSundialsIntegrator
     u::uType
     t::Float64
     tprev::Float64
@@ -19,6 +19,7 @@ mutable struct CVODEIntegrator{uType,memType,solType,algType,fType,JType,oType,t
     sol::solType
     alg::algType
     f::fType
+    userfun::UFType
     jac::JType
     opts::oType
     tout::toutType
@@ -27,15 +28,49 @@ mutable struct CVODEIntegrator{uType,memType,solType,algType,fType,JType,oType,t
     u_modified::Bool
     tmp::tmpType
     uprev::tmpType
+    flag::Cint
 end
 
 function (integrator::CVODEIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T
     out = similar(integrator.u)
-    CVodeGetDky(integrator.mem, t, Cint(T), out)
+    integrator.flag = @checkflag CVodeGetDky(integrator.mem, t, Cint(T), out)
     out
 end
 
 function (integrator::CVODEIntegrator)(out,t::Number,
                                           deriv::Type{Val{T}}=Val{0}) where T
-    CVodeGetDky(integrator.mem, t, Cint(T), out)
+    integrator.flag = @checkflag CVodeGetDky(integrator.mem, t, Cint(T), out)
+end
+
+mutable struct IDAIntegrator{uType,duType,memType,solType,algType,fType,UFType,JType,oType,toutType,sizeType,sizeDType,tmpType} <: AbstractSundialsIntegrator
+    u::uType
+    du::duType
+    t::Float64
+    tprev::Float64
+    mem::memType
+    sol::solType
+    alg::algType
+    f::fType
+    userfun::UFType
+    jac::JType
+    opts::oType
+    tout::toutType
+    tdir::Float64
+    sizeu::sizeType
+    sizedu::sizeDType
+    u_modified::Bool
+    tmp::tmpType
+    uprev::tmpType
+    flag::Cint
+end
+
+function (integrator::IDAIntegrator)(t::Number,deriv::Type{Val{T}}=Val{0}) where T
+    out = similar(integrator.u)
+    integrator.flag = @checkflag IDAGetDky(integrator.mem, t, Cint(T), out)
+    out
+end
+
+function (integrator::IDAIntegrator)(out,t::Number,
+                                          deriv::Type{Val{T}}=Val{0}) where T
+    integrator.flag = @checkflag IDAGetDky(integrator.mem, t, Cint(T), out)
 end

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -1,4 +1,4 @@
-mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType} <: AbstractODEIntegrator
+mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,toutType,sizeType} <: AbstractODEIntegrator
     u::uType
     t::Float64
     mem::memType
@@ -8,6 +8,7 @@ mutable struct SundialsIntegrator{uType,memType,solType,algType,fType,oType,tout
     opts::oType
     tout::toutType
     tdir::Float64
+    sizeu::sizeType
 end
 
 mutable struct DEOptions{SType,TstopType}

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -26,7 +26,7 @@ function handle_callbacks!(integrator)
   integrator.u_modified = false
 end
 
-function DiffEqBase.savevalues!(integrator::SundialsIntegrator)
+function DiffEqBase.savevalues!(integrator::SundialsIntegrator,force_save=false)
     uType = eltype(integrator.sol.u)
     while !isempty(integrator.opts.saveat) &&
         integrator.tdir*top(integrator.opts.saveat) < integrator.tdir*first(integrator.tout)
@@ -37,16 +37,16 @@ function DiffEqBase.savevalues!(integrator::SundialsIntegrator)
         push!(integrator.sol.t,curt)
         if integrator.opts.dense
           tmp = integrator(curt,Val{1})
-          save_value!(integrator.sol.k,tmp,uType,integrator.sizeu,Val{false})
+          save_value!(integrator.sol.interp.du,tmp,uType,integrator.sizeu,Val{false})
         end
     end
-    if integrator.opts.save_everystep
-        tmp = integrator(first(integrator.tout))
-        save_value!(integrator.sol.u,tmp,uType,integrator.sizeu,Val{false})
-        push!(integrator.sol.t, first(integrator.tout))
+
+    if integrator.opts.save_everystep || force_save
+        save_value!(integrator.sol.u,integrator.u,uType,integrator.sizeu)
+        push!(integrator.sol.t, integrator.t)
         if integrator.opts.dense
-          tmp = integrator(first(integrator.tout),Val{1})
-          save_value!(integrator.sol.k,tmp,uType,integrator.sizeu)
+          tmp = integrator(integrator.t,Val{1})
+          save_value!(integrator.sol.interp.du,tmp,uType,integrator.sizeu)
         end
     end
 end

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -26,7 +26,7 @@ function handle_callbacks!(integrator)
   integrator.u_modified = false
 end
 
-function DiffEqBase.savevalues!(integrator::SundialsIntegrator,force_save=false)
+function DiffEqBase.savevalues!(integrator::AbstractSundialsIntegrator,force_save=false)
     uType = eltype(integrator.sol.u)
     while !isempty(integrator.opts.saveat) &&
         integrator.tdir*top(integrator.opts.saveat) < integrator.tdir*first(integrator.tout)
@@ -66,6 +66,6 @@ function save_value!(save_array,val,::Type{T},sizeu,
     push!(save_array,reshape(save,sizeu))
 end
 
-function handle_callback_modifiers!(integrator)
+function handle_callback_modifiers!(integrator::CVODEIntegrator)
   CVodeReInit(integrator.mem,integrator.t,integrator.u)
 end

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -1,0 +1,71 @@
+function handle_callbacks!(integrator)
+  discrete_callbacks = integrator.opts.callback.discrete_callbacks
+  continuous_callbacks = integrator.opts.callback.continuous_callbacks
+  atleast_one_callback = false
+
+  continuous_modified = false
+  discrete_modified = false
+  saved_in_cb = false
+  if !(typeof(continuous_callbacks)<:Tuple{})
+    time,upcrossing,idx,counter = find_first_continuous_callback(integrator,continuous_callbacks...)
+    if time != zero(typeof(integrator.t)) && upcrossing != 0 # if not, then no events
+      continuous_modified,saved_in_cb = apply_callback!(integrator,continuous_callbacks[idx],time,upcrossing)
+    end
+  end
+  if !(typeof(discrete_callbacks)<:Tuple{})
+    discrete_modified,saved_in_cb = apply_discrete_callback!(integrator,discrete_callbacks...)
+  end
+  if !saved_in_cb
+    savevalues!(integrator)
+  end
+
+  integrator.u_modified = continuous_modified || discrete_modified
+  if integrator.u_modified
+    handle_callback_modifiers!(integrator)
+  end
+  integrator.u_modified = false
+end
+
+function DiffEqBase.savevalues!(integrator::SundialsIntegrator)
+    uType = eltype(integrator.sol.u)
+    while !isempty(integrator.opts.saveat) &&
+        integrator.tdir*top(integrator.opts.saveat) < integrator.tdir*first(integrator.tout)
+
+        curt = pop!(integrator.opts.saveat)
+        tmp = integrator(curt)
+        save_value!(integrator.sol.u,tmp,uType,integrator.sizeu,Val{false})
+        push!(integrator.sol.t,curt)
+        if integrator.opts.dense
+          tmp = integrator(curt,Val{1})
+          save_value!(integrator.sol.k,tmp,uType,integrator.sizeu,Val{false})
+        end
+    end
+    if integrator.opts.save_everystep
+        tmp = integrator(first(integrator.tout))
+        save_value!(integrator.sol.u,tmp,uType,integrator.sizeu,Val{false})
+        push!(integrator.sol.t, first(integrator.tout))
+        if integrator.opts.dense
+          tmp = integrator(first(integrator.tout),Val{1})
+          save_value!(integrator.sol.k,tmp,uType,integrator.sizeu)
+        end
+    end
+end
+
+function save_value!(save_array,val,::Type{T},sizeu,
+                     make_copy::Type{Val{bool}}=Val{true}) where {T <: Number,bool}
+    push!(save_array,first(val))
+end
+function save_value!(save_array,val,::Type{T},sizeu,
+                     make_copy::Type{Val{bool}}=Val{true}) where {T <: Vector,bool}
+    bool ? save = copy(val) : save = val
+    push!(save_array,save)
+end
+function save_value!(save_array,val,::Type{T},sizeu,
+                     make_copy::Type{Val{bool}}=Val{true}) where {T <: Array,bool}
+    bool ? save = copy(val) : save = val
+    push!(save_array,reshape(save,sizeu))
+end
+
+function handle_callback_modifiers!(integrator)
+  CVodeReInit(integrator.mem,integrator.t,integrator.u)
+end

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -462,7 +462,7 @@ function solve{uType, duType, tType, isinplace, LinearSolver}(
 
     ### Finishing Routine
 
-    empty!(mem);
+    #empty!(mem);
 
     build_solution(prob, alg, ts, ures,
                    dense = dense,

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -199,13 +199,15 @@ function solve!(integrator)
                 looped = true
                 flag = @checkflag CVode(integrator.mem, integrator.opts.saveat[k], integrator.u, integrator.tout, CV_ONE_STEP)
                 (flag < 0) && break
-                save_value!(integrator.sol.u,integrator.u,uType,integrator.sizeu)
-                push!(integrator.sol.t, integrator.tout...)
-                if integrator.opts.dense
-                  flag = @checkflag CVodeGetDky(
-                                          integrator.mem, integrator.tout[1], Cint(1), integrator.u)
-                  (flag < 0) && break
-                  save_value!(integrator.sol.k,integrator.u,uType,integrator.sizeu)
+                if integrator.opts.save_everystep
+                    save_value!(integrator.sol.u,integrator.u,uType,integrator.sizeu)
+                    push!(integrator.sol.t, integrator.tout...)
+                    if integrator.opts.dense
+                      flag = @checkflag CVodeGetDky(
+                                              integrator.mem, integrator.tout[1], Cint(1), integrator.u)
+                      (flag < 0) && break
+                      save_value!(integrator.sol.k,integrator.u,uType,integrator.sizeu)
+                    end
                 end
                 (flag < 0) && break
             end

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -144,6 +144,8 @@ function DiffEqBase.init{uType, tType, isinplace, Method, LinearSolver}(
                        N_Vector))
       flag = @checkflag CVodeSetUserData(mem, userfun)
       flag = @checkflag CVDlsSetDenseJacFn(mem, jac)
+    else
+        jac = nothing
     end
 
     utmp = NVector(copy(u0))
@@ -169,7 +171,7 @@ function DiffEqBase.init{uType, tType, isinplace, Method, LinearSolver}(
     opts = DEOptions(saveat_internal,tstops_internal,save_everystep,dense,
                      timeseries_errors,dense_errors,save_end,
                      callbacks_internal)
-    SundialsIntegrator(utmp,t0,t0,mem,sol,alg,f!,opts,
+    SundialsIntegrator(utmp,t0,t0,mem,sol,alg,f!,jac,opts,
                        tout,tdir,sizeu,false,tmp,uprev)
 end # function solve
 

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -281,24 +281,6 @@ function DiffEqBase.init{uType, duType, tType, isinplace, LinearSolver}(
     tstops_internal, saveat_internal =
       tstop_saveat_disc_handling(tstops,saveat,tdir,tspan,tType)
 
-
-    if typeof(saveat) <: Number
-        saveat_vec = convert(Vector{tType},saveat+tspan[1]:saveat:(tspan[end]-saveat))
-        # Exclude the endpoint because of floating point issues
-    else
-        saveat_vec = convert(Vector{tType}, collect(saveat))
-    end
-
-    if !isempty(saveat_vec) && saveat_vec[end] == tspan[2]
-        pop!(saveat_vec)
-    end
-
-    if !isempty(saveat_vec) && saveat_vec[1] == tspan[1]
-        save_ts = sort(unique([saveat_vec[2:end];tspan[2];tstops]))
-    else
-        save_ts = sort(unique([saveat_vec;tspan[2];tstops]))
-    end
-
     if typeof(prob.u0) <: Number
         u0 = [prob.u0]
     else
@@ -405,7 +387,7 @@ function DiffEqBase.init{uType, duType, tType, isinplace, LinearSolver}(
             error("Must supply differential_vars argument to DAEProblem constructor to use IDA initial value solver.")
         end
         flag = @checkflag IDASetId(mem, collect(Float64, prob.differential_vars))
-        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, save_ts[1])
+        flag = @checkflag IDACalcIC(mem, IDA_YA_YDP_INIT, t0)
     end
 
     if save_start

--- a/test/common_interface/callbacks.jl
+++ b/test/common_interface/callbacks.jl
@@ -1,0 +1,26 @@
+using Sundials, Base.Test
+
+callback_f = function (t,u,du)
+  du[1] = u[2]
+  du[2] = -9.81
+end
+
+condtion= function (t,u,integrator) # Event when event_f(t,u,k) == 0
+  u[1]
+end
+
+affect! = nothing
+affect_neg! = function (integrator)
+  integrator.u[2] = -integrator.u[2]
+end
+
+callback = ContinuousCallback(condtion,affect!,affect_neg!)
+
+u0 = [50.0,0.0]
+tspan = (0.0,15.0)
+prob = ODEProblem(callback_f,u0,tspan)
+
+sol = solve(prob,CVODE_Adams(),callback=callback)
+@test sol(4.0)[1] > 0
+sol = solve(prob,CVODE_BDF(),callback=callback)
+@test sol(4.0)[1] > 0

--- a/test/common_interface/cvode.jl
+++ b/test/common_interface/cvode.jl
@@ -25,6 +25,9 @@ sol = solve(prob,CVODE_Adams(),saveat=saveat,save_everystep=true,save_start=fals
 
 @test sol.t[1] != 0
 
+sol = solve(prob,CVODE_Adams(),tstops=[0.2,0.5,0.7])
+@test all(t ∈ sol.t for t in [0.2,0.5,0.7])
+
 prob = prob_ode_2Dlinear
 sol = solve(prob,CVODE_BDF())
 sol = solve(prob,CVODE_Adams())

--- a/test/common_interface/errors.jl
+++ b/test/common_interface/errors.jl
@@ -1,4 +1,5 @@
-# Test error handling
+println("Test error handling")
+
 f_error(t,u) = u/t
 u0 = 1.0
 prob = ODEProblem(f_error,u0,(0.0,1.0))

--- a/test/common_interface/errors.jl
+++ b/test/common_interface/errors.jl
@@ -1,3 +1,5 @@
+using Sundials, Base.Test
+
 println("Test error handling")
 
 f_error(t,u) = u/t

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ end
     @testset "IDA" begin include("common_interface/ida.jl") end
     @testset "Jacobians" begin include("common_interface/jacobians.jl") end
     @testset "Errors" begin include("common_interface/errors.jl") end
+    @testset "Callbacks" begin include("common_interface/callbacks.jl") end
 end


### PR DESCRIPTION
This sets up the integrator interface and makes the Sundials ODE algorithms compatible with the callbacks and events.

![newplot 79](https://user-images.githubusercontent.com/1814174/33803678-f1ae75f2-dd49-11e7-9a0c-21f45f937dc9.png)

```julia
using Sundials, Base.Test

callback_f = function (t,u,du)
  du[1] = u[2]
  du[2] = -9.81
end

condtion= function (t,u,integrator) # Event when event_f(t,u,k) == 0
  u[1]
end

affect! = nothing
affect_neg! = function (integrator)
  integrator.u[2] = -integrator.u[2]
end

callback = ContinuousCallback(condtion,affect!,affect_neg!)

u0 = [50.0,0.0]
tspan = (0.0,15.0)
prob = ODEProblem(callback_f,u0,tspan)

sol = solve(prob,CVODE_Adams(),callback=callback)
@test sol(4.0)[1] > 0
sol = solve(prob,CVODE_BDF(),callback=callback)
@test sol(4.0)[1] > 0
```