### PR TITLE
return trimmed solution in cvode

### DIFF
--- a/src/simple.jl
+++ b/src/simple.jl
@@ -174,7 +174,8 @@ return: a solution matrix with time steps in `t` along rows and
         state variable `y` along columns
 """
 function cvode(f::Function, y0::Vector{Float64}, t::AbstractVector, userdata::Any=nothing; kwargs...)
-    n = cvode!(f, zeros(length(t), length(y0)), y0, t, userdata; kwargs...)
+    y = zeros(length(t), length(y0))
+    n = cvode!(f, y, y0, t, userdata; kwargs...)
     return y[1:n,:]
 end
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -173,8 +173,10 @@ end
 return: a solution matrix with time steps in `t` along rows and
         state variable `y` along columns
 """
-cvode(f::Function, y0::Vector{Float64}, t::AbstractVector, userdata::Any=nothing; kwargs...) =
-    cvode!(f, zeros(length(t), length(y0)), y0, t, userdata; kwargs...)
+function cvode(f::Function, y0::Vector{Float64}, t::AbstractVector, userdata::Any=nothing; kwargs...)
+    n = cvode!(f, zeros(length(t), length(y0)), y0, t, userdata; kwargs...)
+    return y[1:n,:]
+end
 
 function cvode!(f::Function, y::Matrix{Float64}, y0::Vector{Float64}, t::AbstractVector, userdata::Any=nothing;
                 integrator=:BDF, reltol::Float64=1e-3, abstol::Float64=1e-6, callback=(x,y,z)->true)
@@ -215,7 +217,7 @@ function cvode!(f::Function, y::Matrix{Float64}, y0::Vector{Float64}, t::Abstrac
     Sundials.SUNLinSolFree_Dense(LS)
     Sundials.SUNMatDestroy_Dense(A)
 
-    return y
+    return c
 end
 
 function idasolfun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::UserFunctionAndData)


### PR DESCRIPTION
7d626e8ba1b4582fe92a54daf2159e52e1cdbd12 broke my code. Because of the callback there is no guarantee that the length of the solution is the same as the inputted arrays. This change makes it so that `cvode!` returns the length of the solution and `cvode` will always return the trimmed solution.