### PR TITLE
Adapt to new error check interface

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -766,7 +766,7 @@ end # function solve
 
 function interpret_sundials_retcode(flag)
   flag >= 0 && return :Success
-  flag == -1 && return :maxiterss
+  flag == -1 && return :MaxIters
   (flag == -2 || flag == -3) && return :Unstable
   flag == -4 && return :ConvergenceFailure
   return :Failure


### PR DESCRIPTION
Similar change as in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/316 to adapt to new interface introduced in https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/99

Since there are already `(integrator.flag < 0) && return` in `step!` implementation (see below), I don't think https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/319 is required for Sundials.

https://github.com/JuliaDiffEq/Sundials.jl/blob/b6bc35770cbeacb77de57a3a5e9e4e71860fbe51/src/common_interface/integrator_types.jl#L162-L196