### PR TITLE
Fix problem callbacks

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -207,8 +207,8 @@ function DiffEqBase.__init(
         jac = nothing
     end
 
-    callback == nothing ? tmp = nothing : tmp = similar(u0)
-    callback == nothing ? uprev = nothing : uprev = similar(u0)
+    callbacks_internal == nothing ? tmp = nothing : tmp = similar(u0)
+    callbacks_internal == nothing ? uprev = nothing : uprev = similar(u0)
     tout = [tspan[1]]
 
     if save_start
@@ -474,8 +474,8 @@ function DiffEqBase.__init(
         jac = nothing
     end
 
-    callback == nothing ? tmp = nothing : tmp = similar(u0)
-    callback == nothing ? uprev = nothing : uprev = similar(u0)
+    callbacks_internal == nothing ? tmp = nothing : tmp = similar(u0)
+    callbacks_internal == nothing ? uprev = nothing : uprev = similar(u0)
     tout = [tspan[1]]
 
     if save_start
@@ -748,8 +748,8 @@ function DiffEqBase.__init(
       end
     end
 
-    callback == nothing ? tmp = nothing : tmp = similar(u0)
-    callback == nothing ? uprev = nothing : uprev = similar(u0)
+    callbacks_internal == nothing ? tmp = nothing : tmp = similar(u0)
+    callbacks_internal == nothing ? uprev = nothing : uprev = similar(u0)
 
     if flag >= 0
         retcode = :Default


### PR DESCRIPTION
I noticed that specifying callbacks in the `DAEProblem` results in error, while specifying them in the `solve` function does not. E.g., the following fails
```
using Sundials
f = function (r, yp, y, p, tres)
    r[1]  = -0.04*y[1] + 1.0e4*y[2]*y[3]
    r[2]  = -r[1] - 3.0e7*y[2]*y[2] - yp[2]
    r[1] -=  yp[1]
    r[3]  =  y[1] + y[2] + y[3] - 1.0
end;
u0 = [1.0, 0, 0];
du0 = [-0.04, 0.04, 0.0];
callback = ContinuousCallback((s, t, ig) -> s[1] - 0.5, ig -> println("Callback at t = $(ig.t)"));
prob = DAEProblem(f, du0, u0, (0.0,100000.0), callback=callback);
sol = solve(prob, IDA());
```
The problem is due to `integrator.uprev` being initialized to `nothing` in `DiffEqBase.__init` when no callback is given to `solve`, even if callbacks are specified in the `DAEProblem`.