### PR TITLE
Matrix-free J*v definitions and preconditioners

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "v3.4.0"
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-Reexport = "fc3a9308-3248-522c-a283-e34d4145d396"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,24 @@
+name = "Sundials"
+uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
+version = "v3.4.0"
+
+[deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+Reexport = "fc3a9308-3248-522c-a283-e34d4145d396"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+[compat]
+julia = ">= 1.0"
+DiffEqBase = ">= 5.5.0"
+DataStructures = ">= 0.15.0"
+
+[extras]
+DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+DiffEqOperators = "9fdde737-9c7f-55bf-ade8-46b3f136cc48"
+
+[targets]
+test = [DiffEqProblemLibrary, ForwardDiff, Compat, DiffEqOperators]

--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,10 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
-julia = ">= 1.0"
+julia = "1"
 DiffEqBase = ">= 5.5.0"
 DataStructures = ">= 0.15.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -21,4 +21,4 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DiffEqOperators = "9fdde737-9c7f-55bf-ade8-46b3f136cc48"
 
 [targets]
-test = [DiffEqProblemLibrary, ForwardDiff, Compat, DiffEqOperators]
+test = ["DiffEqProblemLibrary", "ForwardDiff", "Compat", "DiffEqOperators"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 1.0
-BinaryProvider
-DiffEqBase 5.5.0
-Reexport
-DataStructures 0.15.0

--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -5,7 +5,7 @@ abstract type SundialsODEAlgorithm{Method,LinearSolver} <: DiffEqBase.AbstractOD
 abstract type SundialsDAEAlgorithm{LinearSolver} <: DiffEqBase.AbstractDAEAlgorithm end
 
 # ODE Algorithms
-struct CVODE_BDF{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver}
+struct CVODE_BDF{Method,LinearSolver,P} <: SundialsODEAlgorithm{Method,LinearSolver}
     jac_upper::Int
     jac_lower::Int
     stored_upper::Int
@@ -16,6 +16,7 @@ struct CVODE_BDF{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolve
     max_error_test_failures::Int
     max_nonlinear_iters::Int
     max_convergence_failures::Int
+    prec::P
 end
 Base.@pure function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
                     jac_upper=0,jac_lower=0,stored_upper = jac_upper+jac_lower, non_zero=0,krylov_dim=0,
@@ -24,23 +25,25 @@ Base.@pure function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
                     max_order = 5,
                     max_error_test_failures = 7,
                     max_nonlinear_iters = 3,
-                    max_convergence_failures = 10)
+                    max_convergence_failures = 10
+                    prec = nothing)
     if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
     end
     if linear_solver != :None && linear_solver != :Diagonal && linear_solver != :Dense && linear_solver != :Band && linear_solver != :BCG && linear_solver != :GMRES && linear_solver != :FGMRES && linear_solver != :PCG && linear_solver != :TFQMR && linear_solver != :KLU
         error("Linear solver choice not accepted.")
     end
-    CVODE_BDF{method,linear_solver}(jac_upper,jac_lower,stored_upper,krylov_dim,
+    CVODE_BDF{method,linear_solver, typeof(prec)}(jac_upper,jac_lower,
+                                    stored_upper,krylov_dim,
                                     stability_limit_detect,
                                     max_hnil_warns,
                                     max_order,
                                     max_error_test_failures,
                                     max_nonlinear_iters,
-                                    max_convergence_failures)
+                                    max_convergence_failures, prec)
 end
 
-struct CVODE_Adams{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSolver}
+struct CVODE_Adams{Method,LinearSolver,P} <: SundialsODEAlgorithm{Method,LinearSolver}
     jac_upper::Int
     jac_lower::Int
     stored_upper::Int
@@ -51,6 +54,7 @@ struct CVODE_Adams{Method,LinearSolver} <: SundialsODEAlgorithm{Method,LinearSol
     max_error_test_failures::Int
     max_nonlinear_iters::Int
     max_convergence_failures::Int
+    prec::P
 end
 Base.@pure function CVODE_Adams(;method=:Functional,linear_solver=:None,
                       jac_upper=0,jac_lower=0,
@@ -61,7 +65,8 @@ Base.@pure function CVODE_Adams(;method=:Functional,linear_solver=:None,
                       max_order = 12,
                       max_error_test_failures = 7,
                       max_nonlinear_iters = 3,
-                      max_convergence_failures = 10
+                      max_convergence_failures = 10,
+                      prec = nothing
                       )
     if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
@@ -69,16 +74,17 @@ Base.@pure function CVODE_Adams(;method=:Functional,linear_solver=:None,
     if linear_solver != :None && linear_solver != :Diagonal && linear_solver != :Dense && linear_solver != :Band && linear_solver != :BCG && linear_solver != :GMRES && linear_solver != :FGMRES && linear_solver != :PCG && linear_solver != :TFQMR
         error("Linear solver choice not accepted.")
     end
-    CVODE_Adams{method,linear_solver}(jac_upper,jac_lower,stored_upper,krylov_dim,
+    CVODE_Adams{method,linear_solver,typeof(prec)}(jac_upper,jac_lower,
+                                      stored_upper,krylov_dim,
                                       stability_limit_detect,
                                       max_hnil_warns,
                                       max_order,
                                       max_error_test_failures,
                                       max_nonlinear_iters,
-                                      max_convergence_failures)
+                                      max_convergence_failures,prec)
 end
 
-struct ARKODE{Method,LinearSolver,MassLinearSolver,T,T1,T2} <: SundialsODEAlgorithm{Method,LinearSolver}
+struct ARKODE{Method,LinearSolver,MassLinearSolver,T,T1,T2,P} <: SundialsODEAlgorithm{Method,LinearSolver}
     stiffness::T
     jac_upper::Int
     jac_lower::Int
@@ -103,6 +109,7 @@ struct ARKODE{Method,LinearSolver,MassLinearSolver,T,T1,T2} <: SundialsODEAlgori
     msbp::Int
     itable::T1
     etable::T2
+    prec::P
 end
 
 Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:Dense,
@@ -125,7 +132,8 @@ Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:De
                     msbp = 20,
                     adaptivity_method = 0,
                     itable = nothing,
-                    etable = nothing
+                    etable = nothing,
+                    prec = nothing
                     )
     if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
@@ -138,7 +146,8 @@ Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:De
     end
     ARKODE{method,linear_solver,mass_linear_solver,
                     typeof(stiffness),
-                    typeof(itable),typeof(etable)}(
+                    typeof(itable),typeof(etable),
+                    typeof(prec)}(
                                     stiffness,
                                     jac_upper,jac_lower,
                                     stored_upper,
@@ -159,11 +168,12 @@ Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:De
                                     rdiv,
                                     msbp,
                                     itable,
-                                    etable)
+                                    etable,
+                                    prec)
 end
 
 # DAE Algorithms
-struct IDA{LinearSolver} <: SundialsDAEAlgorithm{LinearSolver}
+struct IDA{LinearSolver,P} <: SundialsDAEAlgorithm{LinearSolver}
   jac_upper::Int
   jac_lower::Int
   stored_upper::Int
@@ -180,6 +190,7 @@ struct IDA{LinearSolver} <: SundialsDAEAlgorithm{LinearSolver}
   max_num_backs_ic::Int
   use_linesearch_ic::Bool
   init_all::Bool
+  prec::P
 end
 Base.@pure function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,
                         stored_upper = jac_upper+jac_lower,
@@ -195,14 +206,15 @@ Base.@pure function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,
                         max_num_backs_ic = 100,
                         use_linesearch_ic = true,
                         init_all = false,
-                        max_convergence_failures = 10)
+                        max_convergence_failures = 10,
+                        prec = nothing)
   if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
       error("Banded solver must set the jac_upper and jac_lower")
   end
   if linear_solver != :Dense && linear_solver != :Band && linear_solver != :BCG && linear_solver != :GMRES && linear_solver != :FGMRES && linear_solver != :PCG && linear_solver != :TFQMR && linear_solver != :KLU
       error("Linear solver choice not accepted.")
   end
-  IDA{linear_solver}(jac_upper,jac_lower,stored_upper,krylov_dim,
+  IDA{linear_solver,typeof(prec)}(jac_upper,jac_lower,stored_upper,krylov_dim,
                       max_order,
                       max_error_test_failures,
                       nonlinear_convergence_coefficient,
@@ -214,7 +226,7 @@ Base.@pure function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,
                       max_num_iters_ic,
                       max_num_backs_ic,
                       use_linesearch_ic,
-                      init_all)
+                      init_all,prec)
 end
 
 method_choice(alg::SundialsODEAlgorithm{Method}) where Method = Method

--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -17,6 +17,7 @@ struct CVODE_BDF{Method,LinearSolver,P} <: SundialsODEAlgorithm{Method,LinearSol
     max_nonlinear_iters::Int
     max_convergence_failures::Int
     prec::P
+    prec_side::Int
 end
 Base.@pure function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
                     jac_upper=0,jac_lower=0,stored_upper = jac_upper+jac_lower, non_zero=0,krylov_dim=0,
@@ -25,8 +26,8 @@ Base.@pure function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
                     max_order = 5,
                     max_error_test_failures = 7,
                     max_nonlinear_iters = 3,
-                    max_convergence_failures = 10
-                    prec = nothing)
+                    max_convergence_failures = 10,
+                    prec = nothing, prec_side = 0)
     if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
     end
@@ -40,7 +41,7 @@ Base.@pure function CVODE_BDF(;method=:Newton,linear_solver=:Dense,
                                     max_order,
                                     max_error_test_failures,
                                     max_nonlinear_iters,
-                                    max_convergence_failures, prec)
+                                    max_convergence_failures, prec, prec_side)
 end
 
 struct CVODE_Adams{Method,LinearSolver,P} <: SundialsODEAlgorithm{Method,LinearSolver}
@@ -55,6 +56,7 @@ struct CVODE_Adams{Method,LinearSolver,P} <: SundialsODEAlgorithm{Method,LinearS
     max_nonlinear_iters::Int
     max_convergence_failures::Int
     prec::P
+    prec_side::Int
 end
 Base.@pure function CVODE_Adams(;method=:Functional,linear_solver=:None,
                       jac_upper=0,jac_lower=0,
@@ -66,7 +68,7 @@ Base.@pure function CVODE_Adams(;method=:Functional,linear_solver=:None,
                       max_error_test_failures = 7,
                       max_nonlinear_iters = 3,
                       max_convergence_failures = 10,
-                      prec = nothing
+                      prec = nothing, prec_side = 0
                       )
     if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
@@ -81,7 +83,7 @@ Base.@pure function CVODE_Adams(;method=:Functional,linear_solver=:None,
                                       max_order,
                                       max_error_test_failures,
                                       max_nonlinear_iters,
-                                      max_convergence_failures,prec)
+                                      max_convergence_failures,prec,prec_side)
 end
 
 struct ARKODE{Method,LinearSolver,MassLinearSolver,T,T1,T2,P} <: SundialsODEAlgorithm{Method,LinearSolver}
@@ -110,6 +112,7 @@ struct ARKODE{Method,LinearSolver,MassLinearSolver,T,T1,T2,P} <: SundialsODEAlgo
     itable::T1
     etable::T2
     prec::P
+    prec_side::Int
 end
 
 Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:Dense,
@@ -133,7 +136,7 @@ Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:De
                     adaptivity_method = 0,
                     itable = nothing,
                     etable = nothing,
-                    prec = nothing
+                    prec = nothing, prec_side = 0
                     )
     if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
         error("Banded solver must set the jac_upper and jac_lower")
@@ -169,7 +172,7 @@ Base.@pure function ARKODE(stiffness=Implicit();method=:Newton,linear_solver=:De
                                     msbp,
                                     itable,
                                     etable,
-                                    prec)
+                                    prec, prec_side)
 end
 
 # DAE Algorithms
@@ -191,6 +194,7 @@ struct IDA{LinearSolver,P} <: SundialsDAEAlgorithm{LinearSolver}
   use_linesearch_ic::Bool
   init_all::Bool
   prec::P
+  prec_side::Int
 end
 Base.@pure function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,
                         stored_upper = jac_upper+jac_lower,
@@ -207,7 +211,7 @@ Base.@pure function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,
                         use_linesearch_ic = true,
                         init_all = false,
                         max_convergence_failures = 10,
-                        prec = nothing)
+                        prec = nothing, prec_side = 0)
   if linear_solver == :Band && (jac_upper==0 || jac_lower==0)
       error("Banded solver must set the jac_upper and jac_lower")
   end
@@ -226,7 +230,7 @@ Base.@pure function IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,
                       max_num_iters_ic,
                       max_num_backs_ic,
                       use_linesearch_ic,
-                      init_all,prec)
+                      init_all,prec, prec_side)
 end
 
 method_choice(alg::SundialsODEAlgorithm{Method}) where Method = Method

--- a/src/common_interface/function_types.jl
+++ b/src/common_interface/function_types.jl
@@ -211,3 +211,15 @@ function massmat(t::Float64,
 
   return IDA_SUCCESS
 end
+
+function jactimes(v::N_Vector,
+                 Jv::N_Vector,
+                 t::Float64,
+                 y::N_Vector,
+                 fy::N_Vector,
+                 fj::AbstactFunJac,
+                 tmp::N_Vector)
+    DiffEqBase.update_coefficients!(fj.jac_prototype,y,fj.p,t)
+    mul!(convert(Vector,Jv),fj.jac_prototype,convert(Vector,v))
+    return CV_SUCCESS
+end

--- a/src/common_interface/function_types.jl
+++ b/src/common_interface/function_types.jl
@@ -1,17 +1,18 @@
 abstract type AbstactFunJac{J2} end
-mutable struct FunJac{F, F2, J, P, M, J2, uType, uType2} <: AbstactFunJac{J2}
+mutable struct FunJac{F, F2, J, P, M, J2, uType, uType2, Prec} <: AbstactFunJac{J2}
     fun::F
     fun2::F2
     jac::J
     p::P
     mass_matrix::M
     jac_prototype::J2
+    prec::Prec
     u::uType
     du::uType
     resid::uType2
 end
-FunJac(fun,jac,p,m,jac_prototype,u,du) = FunJac(fun,nothing,jac,p,m,jac_prototype,u,du,nothing)
-FunJac(fun,jac,p,m,jac_prototype,u,du,resid) = FunJac(fun,nothing,jac,p,m,jac_prototype,u,du,resid)
+FunJac(fun,jac,p,m,jac_prototype,prec,u,du) = FunJac(fun,nothing,jac,p,m,jac_prototype,prec,u,du,nothing)
+FunJac(fun,jac,p,m,jac_prototype,prec,u,du,resid) = FunJac(fun,nothing,jac,p,m,jac_prototype,prec,u,du,resid)
 
 function cvodefunjac(t::Float64,
                      u::N_Vector,
@@ -222,4 +223,47 @@ function jactimes(v::N_Vector,
     DiffEqBase.update_coefficients!(fj.jac_prototype,y,fj.p,t)
     mul!(convert(Vector,Jv),fj.jac_prototype,convert(Vector,v))
     return CV_SUCCESS
+end
+
+function idajactimes(
+                 t::Float64,
+                 y::N_Vector,
+                 fy::N_Vector,
+                 r::N_Vector,
+                 v::N_Vector,
+                 Jv::N_Vector,
+                 cj::Float64,
+                 fj::AbstactFunJac,
+                 tmp1::N_Vector,
+                 tmp2::N_Vector)
+    DiffEqBase.update_coefficients!(fj.jac_prototype,y,fj.p,t)
+    mul!(convert(Vector,Jv),fj.jac_prototype,convert(Vector,v))
+    return IDA_SUCCESS
+end
+
+function precsolve(t::Float64,
+                   y::N_Vector,
+                   fy::N_Vector,
+                   r::N_Vector,
+                   z::N_Vector,
+                   gamma::Float64,
+                   delta::Float64,
+                   lr::Int,
+                   fj::AbstractFunJac)
+    fj.prec(convert(Vector,z),convert(Vector,r),fj.p,t,convert(Vector,y),convert(Vector,fy),gamma,delta,lr)
+    return CV_SUCCESS
+end
+
+function idaprecsolve(t::Float64,
+                   y::N_Vector,
+                   fy::N_Vector,
+                   resid::N_Vector,
+                   r::N_Vector,
+                   z::N_Vector,
+                   gamma::Float64,
+                   delta::Float64,
+                   lr::Int,
+                   fj::AbstractFunJac)
+    fj.prec(convert(Vector,z),convert(Vector,r),fj.p,t,convert(Vector,y),convert(Vector,fy),convert(Vector,resid),gamma,delta,lr)
+    return IDA_SUCCESS
 end

--- a/src/common_interface/function_types.jl
+++ b/src/common_interface/function_types.jl
@@ -1,5 +1,5 @@
-abstract type AbstactFunJac{J2} end
-mutable struct FunJac{F, F2, J, P, M, J2, uType, uType2, Prec} <: AbstactFunJac{J2}
+abstract type AbstractFunJac{J2} end
+mutable struct FunJac{F, F2, J, P, M, J2, uType, uType2, Prec} <: AbstractFunJac{J2}
     fun::F
     fun2::F2
     jac::J
@@ -58,7 +58,7 @@ function cvodejac(t::realtype,
                   u::N_Vector,
                   du::N_Vector,
                   J::SUNMatrix,
-                  funjac::AbstactFunJac{Nothing},
+                  funjac::AbstractFunJac{Nothing},
                   tmp1::N_Vector,
                   tmp2::N_Vector,
                   tmp3::N_Vector)
@@ -84,7 +84,7 @@ function cvodejac(t::realtype,
                   u::N_Vector,
                   du::N_Vector,
                   _J::SUNMatrix,
-                  funjac::AbstactFunJac{<:SparseMatrixCSC},
+                  funjac::AbstractFunJac{<:SparseMatrixCSC},
                   tmp1::N_Vector,
                   tmp2::N_Vector,
                   tmp3::N_Vector)
@@ -135,7 +135,7 @@ function idajac(t::realtype,
                 du::N_Vector,
                 res::N_Vector,
                 J::SUNMatrix,
-                funjac::AbstactFunJac{Nothing},
+                funjac::AbstractFunJac{Nothing},
                 tmp1::N_Vector,
                 tmp2::N_Vector,
                 tmp3::N_Vector)
@@ -166,7 +166,7 @@ function idajac(t::realtype,
                 du::N_Vector,
                 res::N_Vector,
                 _J::SUNMatrix,
-                funjac::AbstactFunJac{<:SparseMatrixCSC},
+                funjac::AbstractFunJac{<:SparseMatrixCSC},
                 tmp1::N_Vector,
                 tmp2::N_Vector,
                 tmp3::N_Vector)
@@ -199,7 +199,7 @@ end
 
 function massmat(t::Float64,
                  _M::SUNMatrix,
-                 mmf::AbstactFunJac,
+                 mmf::AbstractFunJac,
                  tmp1::N_Vector,
                  tmp2::N_Vector,
                  tmp3::N_Vector)
@@ -218,7 +218,7 @@ function jactimes(v::N_Vector,
                  t::Float64,
                  y::N_Vector,
                  fy::N_Vector,
-                 fj::AbstactFunJac,
+                 fj::AbstractFunJac,
                  tmp::N_Vector)
     DiffEqBase.update_coefficients!(fj.jac_prototype,y,fj.p,t)
     mul!(convert(Vector,Jv),fj.jac_prototype,convert(Vector,v))
@@ -233,7 +233,7 @@ function idajactimes(
                  v::N_Vector,
                  Jv::N_Vector,
                  cj::Float64,
-                 fj::AbstactFunJac,
+                 fj::AbstractFunJac,
                  tmp1::N_Vector,
                  tmp2::N_Vector)
     DiffEqBase.update_coefficients!(fj.jac_prototype,y,fj.p,t)

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -503,9 +503,10 @@ function DiffEqBase.__init(
         _LS = nothing
     end
 
-    if (typeof(prob) <: SplitODEProblem &&
+    if (typeof(prob.problem_type) <: SplitODEProblem &&
        typeof(prob.f.f1.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator) ||
-       typeof(f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
+       (!(typeof(prob.problem_type) <: SplitODEProblem) && 
+       <: typeof(f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator)
         jtimes = old_cfunction(jactimes,
                         Cint,
                         Tuple{N_Vector,

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -506,7 +506,7 @@ function DiffEqBase.__init(
     if (typeof(prob.problem_type) <: SplitODEProblem &&
        typeof(prob.f.f1.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator) ||
        (!(typeof(prob.problem_type) <: SplitODEProblem) &&
-       <: typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator)
+       typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator)
         jtimes = old_cfunction(jactimes,
                         Cint,
                         Tuple{N_Vector,

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -233,6 +233,18 @@ function DiffEqBase.__init(
         CVSpilsSetJacTimes(mem, C_NULL, jtimes)
     end
 
+    if alg.prec !=== nothing
+        precfun = old_cfunction(precsolve,
+                        Cint,
+                        Tuple{Float64,
+                         N_Vector,
+                         N_Vector,
+                         N_Vector,
+                         N_Vector,Float64,Float64,Int,
+                         Ref{typeof(userfun)})
+        CVSpilsSetPreconditioner(mem, C_NULL, precfun)
+    end
+
     callbacks_internal == nothing ? tmp = nothing : tmp = similar(u0)
     callbacks_internal == nothing ? uprev = nothing : uprev = similar(u0)
     tout = [tspan[1]]
@@ -584,6 +596,18 @@ function DiffEqBase.__init(
         jac = nothing
     end
 
+    if alg.prec !=== nothing
+        precfun = old_cfunction(precsolve,
+                        Cint,
+                        Tuple{Float64,
+                         N_Vector,
+                         N_Vector,
+                         N_Vector,
+                         N_Vector,Float64,Float64,Int,
+                         Ref{typeof(userfun)})
+        ARKSpilsSetPreconditioner(mem, C_NULL, precfun)
+    end
+
     callbacks_internal == nothing ? tmp = nothing : tmp = similar(u0)
     callbacks_internal == nothing ? uprev = nothing : uprev = similar(u0)
     tout = [tspan[1]]
@@ -817,16 +841,26 @@ function DiffEqBase.__init(
     end
 
     if typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
-        jtimes = old_cfunction(jactimes,
+        jtimes = old_cfunction(idajactimes,
                         Cint,
-                        Tuple{N_Vector,
-                         N_Vector,
+                        Tuple{realtype,
+                         N_Vector,N_Vector,N_Vector,N_Vector,N_Vector,
                          realtype,
-                         N_Vector,
-                         N_Vector,
                          Ref{typeof(userfun)},
-                         N_Vector})
+                         N_Vector,N_Vector})
         IDASpilsSetJacTimes(mem, C_NULL, jtimes)
+    end
+
+    if alg.prec !=== nothing
+        precfun = old_cfunction(idaprecsolve,
+                        Cint,
+                        Tuple{Float64,
+                         N_Vector,
+                         N_Vector,
+                         N_Vector,
+                         N_Vector,N_Vector,Float64,Float64,Int,
+                         Ref{typeof(userfun)})
+        IDASpilsSetPreconditioner(mem, C_NULL, precfun)
     end
 
     if DiffEqBase.has_jac(prob.f)

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -503,7 +503,9 @@ function DiffEqBase.__init(
         _LS = nothing
     end
 
-    if typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
+    if (typeof(prob) <: SplitODEProblem &&
+       typeof(prob.f.f1.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator) ||
+       typeof(f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
         jtimes = old_cfunction(jactimes,
                         Cint,
                         Tuple{N_Vector,

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -220,6 +220,19 @@ function DiffEqBase.__init(
         jac = nothing
     end
 
+    if typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
+        jtimes = old_cfunction(jactimes,
+                        Cint,
+                        Tuple{N_Vector,
+                         N_Vector,
+                         realtype,
+                         N_Vector,
+                         N_Vector,
+                         Ref{typeof(userfun)},
+                         N_Vector})
+        CVSpilsSetJacTimes(mem, C_NULL, jtimes)
+    end
+
     callbacks_internal == nothing ? tmp = nothing : tmp = similar(u0)
     callbacks_internal == nothing ? uprev = nothing : uprev = similar(u0)
     tout = [tspan[1]]
@@ -476,6 +489,19 @@ function DiffEqBase.__init(
     else
         _A = nothing
         _LS = nothing
+    end
+
+    if typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
+        jtimes = old_cfunction(jactimes,
+                        Cint,
+                        Tuple{N_Vector,
+                         N_Vector,
+                         realtype,
+                         N_Vector,
+                         N_Vector,
+                         Ref{typeof(userfun)},
+                         N_Vector})
+        ARKodeSpilsSetJacTimes(mem, C_NULL, jtimes)
     end
 
     if prob.f.mass_matrix != I
@@ -788,6 +814,19 @@ function DiffEqBase.__init(
         flag = IDADlsSetLinearSolver(mem, LS, A)
         _A = MatrixHandle(A,SparseMatrix())
         _LS = LinSolHandle(LS,KLU())
+    end
+
+    if typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator
+        jtimes = old_cfunction(jactimes,
+                        Cint,
+                        Tuple{N_Vector,
+                         N_Vector,
+                         realtype,
+                         N_Vector,
+                         N_Vector,
+                         Ref{typeof(userfun)},
+                         N_Vector})
+        IDASpilsSetJacTimes(mem, C_NULL, jtimes)
     end
 
     if DiffEqBase.has_jac(prob.f)

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -505,8 +505,8 @@ function DiffEqBase.__init(
 
     if (typeof(prob.problem_type) <: SplitODEProblem &&
        typeof(prob.f.f1.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator) ||
-       (!(typeof(prob.problem_type) <: SplitODEProblem) && 
-       <: typeof(f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator)
+       (!(typeof(prob.problem_type) <: SplitODEProblem) &&
+       <: typeof(prob.f.jac_prototype) <: DiffEqBase.AbstractDiffEqLinearOperator)
         jtimes = old_cfunction(jactimes,
                         Cint,
                         Tuple{N_Vector,

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -122,7 +122,7 @@ function DiffEqBase.__init(
     _u0 = copy(u0)
     utmp = NVector(_u0)
 
-    userfun = FunJac(f!,prob.f.jac,prob.p,nothing,prob.f.jac_prototype,u0,_u0)
+    userfun = FunJac(f!,prob.f.jac,prob.p,nothing,prob.f.jac_prototype,alg.prec,u0,_u0)
 
     flag = CVodeInit(mem,
                      old_cfunction(cvodefunjac, Cint,
@@ -166,27 +166,27 @@ function DiffEqBase.__init(
             _A = nothing
             _LS = nothing
         elseif LinearSolver == :GMRES
-            LS = SUNSPGMR(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPGMR(u0, alg.prec_side, alg.krylov_dim)
             flag = CVSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = Sundials.LinSolHandle(LS,Sundials.SPGMR())
         elseif LinearSolver == :FGMRES
-            LS = SUNSPFGMR(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPFGMR(u0, alg.prec_side, alg.krylov_dim)
             flag = CVSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,SPFGMR())
         elseif LinearSolver == :BCG
-            LS = SUNSPBCGS(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPBCGS(u0, alg.prec_side, alg.krylov_dim)
             flag = CVSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,SPBCGS())
         elseif LinearSolver == :PCG
-            LS = SUNPCG(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNPCG(u0, alg.prec_side, alg.krylov_dim)
             flag = CVSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,PCG())
         elseif LinearSolver == :TFQMR
-            LS = SUNSPTFQMR(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPTFQMR(u0, alg.prec_side, alg.krylov_dim)
             flag = CVSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,PTFQMR())
@@ -233,7 +233,7 @@ function DiffEqBase.__init(
         CVSpilsSetJacTimes(mem, C_NULL, jtimes)
     end
 
-    if alg.prec !=== nothing
+    if alg.prec !== nothing
         precfun = old_cfunction(precsolve,
                         Cint,
                         Tuple{Float64,
@@ -241,7 +241,7 @@ function DiffEqBase.__init(
                          N_Vector,
                          N_Vector,
                          N_Vector,Float64,Float64,Int,
-                         Ref{typeof(userfun)})
+                         Ref{typeof(userfun)}})
         CVSpilsSetPreconditioner(mem, C_NULL, precfun)
     end
 
@@ -383,7 +383,7 @@ function DiffEqBase.__init(
         end
 
         userfun = FunJac(f1!,f2!,prob.f.f1.jac,prob.p,prob.f.mass_matrix,
-                         prob.f.f1.jac_prototype,u0,_u0,nothing)
+                         prob.f.f1.jac_prototype,alg.prec,u0,_u0,nothing)
         flag = ARKodeInit(mem,
                     old_cfunction(cvodefunjac, Cint,
                              Tuple{realtype, N_Vector,
@@ -393,7 +393,7 @@ function DiffEqBase.__init(
                              N_Vector, Ref{typeof(userfun)}}),
                     t0, convert(N_Vector, u0nv))
     else
-        userfun = FunJac(f!,prob.f.jac,prob.p,prob.f.mass_matrix,prob.f.jac_prototype,u0,_u0)
+        userfun = FunJac(f!,prob.f.jac,prob.p,prob.f.mass_matrix,prob.f.jac_prototype,alg.prec,u0,_u0)
         if alg.stiffness == Explicit()
             flag = ARKodeInit(mem,
                         old_cfunction(cvodefunjac, Cint,
@@ -464,27 +464,27 @@ function DiffEqBase.__init(
             _A = MatrixHandle(A,BandMatrix())
             _LS = LinSolHandle(LS,Band())
         elseif LinearSolver == :GMRES
-            LS = SUNSPGMR(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPGMR(u0, alg.prec_side, alg.krylov_dim)
             flag = ARKSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = Sundials.LinSolHandle(LS,Sundials.SPGMR())
         elseif LinearSolver == :FGMRES
-            LS = SUNSPFGMR(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPFGMR(u0, alg.prec_side, alg.krylov_dim)
             flag = ARKSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,SPFGMR())
         elseif LinearSolver == :BCG
-            LS = SUNSPBCGS(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPBCGS(u0, alg.prec_side, alg.krylov_dim)
             flag = ARKSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,SPBCGS())
         elseif LinearSolver == :PCG
-            LS = SUNPCG(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNPCG(u0, alg.prec_side, alg.krylov_dim)
             flag = ARKSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,PCG())
         elseif LinearSolver == :TFQMR
-            LS = SUNSPTFQMR(u0, PREC_NONE, alg.krylov_dim)
+            LS = SUNSPTFQMR(u0, alg.prec_side, alg.krylov_dim)
             flag = ARKSpilsSetLinearSolver(mem, LS)
             _A = nothing
             _LS = LinSolHandle(LS,PTFQMR())
@@ -531,27 +531,27 @@ function DiffEqBase.__init(
             _M = MatrixHandle(M,BandMatrix())
             _MLS = LinSolHandle(MLS,Band())
         elseif MassLinearSolver == :GMRES
-            MLS = SUNSPGMR(u0, PREC_NONE, alg.mass_krylov_dim)
+            MLS = SUNSPGMR(u0, alg.prec_side, alg.mass_krylov_dim)
             ARKSpilsSetMassLinearSolver(mem,MLS,false)
             _M = nothing
             _MLS = LinSolHandle(MLS,SPGMR())
         elseif MassLinearSolver == :FGMRES
-            MLS = SUNSPGMR(u0, PREC_NONE, alg.mass_krylov_dim)
+            MLS = SUNSPGMR(u0, alg.prec_side, alg.mass_krylov_dim)
             ARKSpilsSetMassLinearSolver(mem,MLS,false)
             _M = nothing
             _MLS = LinSolHandle(MLS,SPFGMR())
         elseif MassLinearSolver == :BCG
-            MLS = SUNSPGMR(u0, PREC_NONE, alg.mass_krylov_dim)
+            MLS = SUNSPGMR(u0, alg.prec_side, alg.mass_krylov_dim)
             ARKSpilsSetMassLinearSolver(mem,MLS,false)
             _M = nothing
             _MLS = LinSolHandle(MLS,SPBCGS())
         elseif MassLinearSolver == :PCG
-            MLS = SUNSPGMR(u0, PREC_NONE, alg.mass_krylov_dim)
+            MLS = SUNSPGMR(u0, alg.prec_side, alg.mass_krylov_dim)
             ARKSpilsSetMassLinearSolver(mem,MLS,false)
             _M = nothing
             _MLS = LinSolHandle(MLS,PCG())
         elseif MassLinearSolver == :TFQMR
-            MLS = SUNSPGMR(u0, PREC_NONE, alg.mass_krylov_dim)
+            MLS = SUNSPGMR(u0, alg.prec_side, alg.mass_krylov_dim)
             ARKSpilsSetMassLinearSolver(mem,MLS,false)
             _M = nothing
             _MLS = LinSolHandle(MLS,PTFQMR())
@@ -596,7 +596,7 @@ function DiffEqBase.__init(
         jac = nothing
     end
 
-    if alg.prec !=== nothing
+    if alg.prec !== nothing
         precfun = old_cfunction(precsolve,
                         Cint,
                         Tuple{Float64,
@@ -604,7 +604,7 @@ function DiffEqBase.__init(
                          N_Vector,
                          N_Vector,
                          N_Vector,Float64,Float64,Int,
-                         Ref{typeof(userfun)})
+                         Ref{typeof(userfun)}})
         ARKSpilsSetPreconditioner(mem, C_NULL, precfun)
     end
 
@@ -764,7 +764,7 @@ function DiffEqBase.__init(
     dutmp = NVector(_du0)
     rtest = zeros(length(u0))
 
-    userfun = FunJac(f!,prob.f.jac,prob.p,nothing,prob.f.jac_prototype,_u0,_du0,rtest)
+    userfun = FunJac(f!,prob.f.jac,prob.p,nothing,prob.f.jac_prototype,alg.prec,_u0,_du0,rtest)
 
     u0nv = NVector(u0)
     flag = IDAInit(mem, old_cfunction(idasolfun,
@@ -807,27 +807,27 @@ function DiffEqBase.__init(
         _A = MatrixHandle(A,BandMatrix())
         _LS = LinSolHandle(LS,Band())
     elseif LinearSolver == :GMRES
-        LS = SUNSPGMR(u0, PREC_NONE, alg.krylov_dim)
+        LS = SUNSPGMR(u0, alg.prec_side, alg.krylov_dim)
         flag = IDASpilsSetLinearSolver(mem, LS)
         _A = nothing
         _LS = LinSolHandle(LS,SPGMR())
     elseif LinearSolver == :FGMRES
-        LS = SUNSPFGMR(u0, PREC_NONE, alg.krylov_dim)
+        LS = SUNSPFGMR(u0, alg.prec_side, alg.krylov_dim)
         flag = IDASpilsSetLinearSolver(mem, LS)
         _A = nothing
         _LS = LinSolHandle(LS,SPFGMR())
     elseif LinearSolver == :BCG
-        LS = SUNSPBCGS(u0, PREC_NONE, alg.krylov_dim)
+        LS = SUNSPBCGS(u0, alg.prec_side, alg.krylov_dim)
         flag = IDASpilsSetLinearSolver(mem, LS)
         _A = nothing
         _LS = LinSolHandle(LS,SPBCGS())
     elseif LinearSolver == :PCG
-        LS = SUNPCG(u0, PREC_NONE, alg.krylov_dim)
+        LS = SUNPCG(u0, alg.prec_side, alg.krylov_dim)
         flag = IDASpilsSetLinearSolver(mem, LS)
         _A = nothing
         _LS = LinSolHandle(LS,PCG())
     elseif LinearSolver == :TFQMR
-        LS = SUNSPTFQMR(u0, PREC_NONE, alg.krylov_dim)
+        LS = SUNSPTFQMR(u0, alg.prec_side, alg.krylov_dim)
         flag = IDASpilsSetLinearSolver(mem, LS)
         _A = nothing
         _LS = LinSolHandle(LS,PTFQMR())
@@ -851,7 +851,7 @@ function DiffEqBase.__init(
         IDASpilsSetJacTimes(mem, C_NULL, jtimes)
     end
 
-    if alg.prec !=== nothing
+    if alg.prec !== nothing
         precfun = old_cfunction(idaprecsolve,
                         Cint,
                         Tuple{Float64,
@@ -859,7 +859,7 @@ function DiffEqBase.__init(
                          N_Vector,
                          N_Vector,
                          N_Vector,N_Vector,Float64,Float64,Int,
-                         Ref{typeof(userfun)})
+                         Ref{typeof(userfun)}})
         IDASpilsSetPreconditioner(mem, C_NULL, precfun)
     end
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -15,9 +15,9 @@ macro checkflag(ex,throw_error=false)
         flag = $(esc(ex))
         if flag < 0
             if $(esc(throw_error))
-                error($(string(fname, " failed with error code = ")), flag)
+                @error($(string(fname, " failed with error code = ")), flag)
             else
-                warn($(string(fname, " failed with error code = ")), flag)
+                @warn($(string(fname, " failed with error code = ")), flag)
             end
         end
         flag

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,0 @@
-DiffEqProblemLibrary
-ForwardDiff
-Compat
-DiffEqOperators

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 DiffEqProblemLibrary
 ForwardDiff
 Compat
+DiffEqOperators

--- a/test/common_interface/cvode.jl
+++ b/test/common_interface/cvode.jl
@@ -78,8 +78,10 @@ sol8 = solve(prob,CVODE_BDF(linear_solver=:TFQMR))
 #@test isapprox(sol1[end],sol9[end],rtol=1e-3)
 
 # Test identity preconditioner
-sol4 = solve(prob,CVODE_BDF(linear_solver=:GMRES,prec=(z,r,p,t,y,fy,gamma,delta,lr)->z.=r))
+global prec_used = false
+sol4 = solve(prob,CVODE_BDF(linear_solver=:GMRES, prec_side = 3, prec=(z,r,p,t,y,fy,gamma,delta,lr)->(global prec_used=true;z.=r)))
 @test isapprox(sol1[end],sol4[end],rtol=1e-3)
+@test prec_used
 
 # Backwards
 prob = deepcopy(prob_ode_2Dlinear)

--- a/test/common_interface/cvode.jl
+++ b/test/common_interface/cvode.jl
@@ -76,6 +76,11 @@ sol8 = solve(prob,CVODE_BDF(linear_solver=:TFQMR))
 @test isapprox(sol1[end],sol7[end],rtol=1e-3)
 @test isapprox(sol1[end],sol8[end],rtol=1e-3)
 #@test isapprox(sol1[end],sol9[end],rtol=1e-3)
+
+# Test identity preconditioner
+sol4 = solve(prob,CVODE_BDF(linear_solver=:GMRES,prec=(z,r,p,t,y,fy,gamma,delta,lr)->z.=r))
+@test isapprox(sol1[end],sol4[end],rtol=1e-3)
+
 # Backwards
 prob = deepcopy(prob_ode_2Dlinear)
 prob2 = ODEProblem(prob.f,prob.u0,(1.0,0.0),1.01)

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -15,6 +15,14 @@ sol5 = solve(prob,IDA(linear_solver=:TFQMR))
 sol6 = solve(prob,IDA(linear_solver=:FGMRES))
 sol7 = solve(prob,IDA(linear_solver=:PCG)) # Requires symmetric linear
 
+# Test identity preconditioner
+global prec_used = false
+sol4 = solve(prob,IDA(linear_solver=:GMRES,
+             prec_side = 3,
+             prec=(z,r,p,t,y,fy,resid,gamma,delta,lr)->(global prec_used=true;z.=r)))
+@test prec_used
+
+
 sol = solve(prob,IDA(),saveat=saveat)
 
 @test sol.t == saveat

--- a/test/common_interface/jacobians.jl
+++ b/test/common_interface/jacobians.jl
@@ -1,4 +1,4 @@
-using Sundials, Test, SparseArrays
+using Sundials, Test, SparseArrays, DiffEqOperators
 
 # Test for Jacobian usage
 function Lotka(du, u, p, t)
@@ -30,6 +30,12 @@ prob = ODEProblem(Lotka_f,ones(2),(0.0,10.0))
 jac_called = false
 sol9 = solve(prob,CVODE_BDF(linear_solver=:KLU))
 @test jac_called == true
+
+Lotka_fj = ODEFunction(Lotka,
+                      jac_prototype = JacVecOperator{Float64}(Lotka,ones(2)))
+
+prob = ODEProblem(Lotka_fj,ones(2),(0.0,10.0))
+sol9 = solve(prob,CVODE_BDF(linear_solver=:GMRES))
 
 function f2!(res, du, u, p, t)
     res[1] = 1.01du[1]


### PR DESCRIPTION
Solves https://github.com/JuliaDiffEq/Sundials.jl/issues/145 . It uses the common interface for Jacobian types to specify a J*v function, and a special `prec` function was added to the algorithm for specifying a preconditioner.