### PR TITLE
missing entries in [deps] Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
There are 3 missing [deps] entries in Project.toml, causing `using DifferentialEquations` to fail in compile caches:

in your ci log: https://ci.appveyor.com/project/ChrisRackauckas/sundials-jl/branch/master/job/5x7ce7w0whhe899f#L125

in fixed ci: (no warning now ) https://travis-ci.org/daviehh/Sundials.jl/jobs/527887054

locally:

```
> using DifferentialEquations

[ Info: Recompiling stale cache file /Users/david/.julia/compiled/v1.1/DifferentialEquations/UQdwS.ji for DifferentialEquations [0c46a032-eb83-5123-abaf-570d42b7fbaa]
┌ Warning: Package Sundials does not have SparseArrays in its dependencies:
│ - If you have Sundials checked out for development and have
│   added SparseArrays as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Sundials
└ Loading SparseArrays into Sundials from project dependency, future warnings for Sundials are suppressed.
┌ Warning: The call to compilecache failed to create a usable precompiled cache file for DifferentialEquations [0c46a032-eb83-5123-abaf-570d42b7fbaa]
│   exception = Required dependency Sundials [c3572dad-4567-51f8-b174-8c6c989267f4] failed to load from a cache file.
└ @ Base loading.jl:969
[ Info: Recompiling stale cache file /Users/david/.julia/compiled/v1.1/Sundials/j8Ppj.ji for Sundials [c3572dad-4567-51f8-b174-8c6c989267f4]
┌ Warning: Package Sundials does not have SparseArrays in its dependencies:
│ - If you have Sundials checked out for development and have
│   added SparseArrays as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Sundials
└ Loading SparseArrays into Sundials from project dependency, future warnings for Sundials are suppressed.
```