### PR TITLE
add call to IDASetId when using IDA_YA_YDP_INIT

### DIFF
--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -97,6 +97,7 @@ function handle_callback_modifiers!(integrator::IDAIntegrator)
           init_type = IDA_Y_INIT
       else
           init_type = IDA_YA_YDP_INIT
+          integrator.flag = IDASetId(integrator.mem, integrator.sol.prob.differential_vars)
       end
       integrator.flag = IDACalcIC(integrator.mem, init_type, integrator.dt)
   end


### PR DESCRIPTION
According to Sundials Manual when the `IDA_YA_YDP_INIT` method is used in `IDACalcIC` the ID's to differentiate the differential and algebraic equations need to be set. 

This PR adds the function call in the callback initializer and removes the error `id = NULL conflicts with icopt.` 

Testing with https://gist.github.com/jd-lara/78bbc5fd63a2229d7e1956be5882f88e returns the correct result. 

<img width="620" alt="image" src="https://user-images.githubusercontent.com/16385323/59653610-f3c92380-914f-11e9-8473-a08a4c2fc85c.png">
