### PR TITLE
Fix possible GC bug

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -883,8 +883,8 @@ function DiffEqBase.__init(
     end
     cfun = getcfun(userfun)
     flag = IDAInit(mem, cfun,
-                    t0, convert(N_Vector, u0),
-                    convert(N_Vector, du0))
+                    t0, convert(N_Vector, utmp),
+                    convert(N_Vector, dutmp))
     dt != nothing && (flag = IDASetInitStep(mem, dt))
     flag = IDASetUserData(mem, userfun)
     flag = IDASetMaxStep(mem, dtmax)


### PR DESCRIPTION
```julia
""" `N_Vector(v::Vector{T})`
    Converts Julia `Vector` to `N_Vector`.
    Implicitly creates `NVector` object that manages automatic
    destruction of `N_Vector` object when no longer in use.
"""
Base.convert(::Type{N_Vector}, v::Vector{realtype}) = N_Vector(NVector(v))
Base.convert(::Type{N_Vector}, v::Vector{T}) where {T<:Real} = N_Vector(NVector(v))
```
and so using u0 and du0 correctly can cause them to be GC'd accidentally, causing a segfault.